### PR TITLE
Chore : output, filename 옵션 삭제

### DIFF
--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -9,7 +9,6 @@ module.exports = {
   target: 'node',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
     clean: true,
   },
   resolve: {


### PR DESCRIPTION
## What did you do?

<!--무엇을 하셨나요?-->
웹팩 컨픽에서 output - filename 옵션을 제거했어요!
=> 엔트리 포인트도 하나이고 엔트리포인트 이름도 지정해주지 않아 필요 없는데 왜 추가 했었는지 모르겠네요🤣
