### PR TITLE
react app 빌드 스크립트 추가  close #8

### DIFF
--- a/.github/workflows/check-build-express.yml
+++ b/.github/workflows/check-build-express.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Check dist/
+name: Check Build Express App/
 
 # Controls when the workflow will run
 on:
@@ -18,7 +18,6 @@ on:
   workflow_dispatch:
 
 env:
-  client-directory: ./client
   server-directory: ./server
 
 jobs:
@@ -49,7 +48,6 @@ jobs:
         working-directory:  ${{env.server-directory}}
         run:
           npm run build
-      # If index.js was different than expected, upload the expected version as an artifact
       - uses: actions/upload-artifact@v2
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:

--- a/.github/workflows/check-build-react-strict.yml
+++ b/.github/workflows/check-build-react-strict.yml
@@ -1,27 +1,25 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Check Build Express App/
+name: Check Build React App/
 
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the dev branch
   push:
     branches:
-      - dev
       - release
     paths-ignore:
       - '**.md'
   pull_request:
     branches:
-      - dev
       - release
-
     paths-ignore:
       - '**.md'
   workflow_dispatch:
 
 env:
-  server-directory: ./server
+  client-directory: ./client
+  CI: true
 
 jobs:
   check-dist:
@@ -35,20 +33,12 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Server npm install
-        working-directory: ${{env.server-directory}}
+      - name: Client npm install
+        working-directory: ${{env.client-directory}}
         run: npm install
     
-      - name: Create .env file
-        working-directory:  ${{env.server-directory}}
-        run: |
-          touch .env
-          echo DB_USER=${{ secrets.DB_USER }}\ >> .env
-          echo DB_PASSWORD=${{ secrets.DB_PASSWORD }}\ >> .env
-          cat .env
-
-      - name: Rebuild the dist/ directory
-        working-directory:  ${{env.server-directory}}
+      - name: Run Client Test
+        working-directory:  ${{env.client-directory}}
         run:
           npm run build
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/check-build-react.yml
+++ b/.github/workflows/check-build-react.yml
@@ -1,0 +1,47 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Check Build React App/
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the dev branch
+  push:
+    branches:
+      - dev
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - dev
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+env:
+  client-directory: ./client
+
+jobs:
+  check-dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: 16.x
+
+      - name: Client npm install
+        working-directory: ${{env.client-directory}}
+        run: npm install
+    
+      - name: Run Client Test
+        working-directory:  ${{env.client-directory}}
+        run:
+          npm run build
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/check-build-react.yml
+++ b/.github/workflows/check-build-react.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   client-directory: ./client
+  CI: false
 
 jobs:
   check-dist:

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "client",
       "version": "0.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.2",


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#8 

## What did you do?

<!--무엇을 하셨나요?-->
- [x] client 폴더 속 앱 빌드하는 스크립트 추가

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
* 왜 한번에 CI 스크립트를 돌리지 않으시나요?
일단 두 파일은 나중에 따로 빌드될 것이며,
에러가 난다면 어디 빌드에서 에러가 나는지 보기 쉬울 거라고 생각했기 때문!
* 왜 테스트 코드를 돌리지 않나요?
나중에 빌드 명령어에 테스트 돌리는게 포함될 것이기 때문!

