### PR TITLE
Feature/signup validation

### DIFF
--- a/server/src/controller/user.controller.ts
+++ b/server/src/controller/user.controller.ts
@@ -68,8 +68,8 @@ const signIn = async (req: Request, res: Response, next: NextFunction) => {
     const user = await userRepository.findOne({ where: { loginID: loginID } });
     if (!user) return res.status(400).send('존재하지 않는 회원입니다.');
 
-    const isPasswordValid = await compare(password, user.password);
-    if (!isPasswordValid) return res.status(400).send('비밀번호가 올바르지 않습니다.');
+    const isValidPassword = await compare(password, user.password);
+    if (!isValidPassword) return res.status(400).send('비밀번호가 올바르지 않습니다.');
 
     req.session.userID = user.id;
     return res.status(200).send('로그인 성공!');

--- a/server/src/controller/user.controller.ts
+++ b/server/src/controller/user.controller.ts
@@ -10,17 +10,44 @@ declare module 'express-session' {
 }
 
 const saltRounds = 10;
-const nullCheck = (data) => data !== undefined && data !== null && data !== '';
+const nullCheck = (data) => {
+  const trimedData = data.trim();
+  return trimedData !== undefined && trimedData !== null && trimedData !== '';
+};
+const loginIDRegex = /^[a-z][a-z0-9]{5,14}$/;
+const loginIDValidation = (loginID) => loginIDRegex.test(loginID);
+const usernameRegex = /^[^\s]{1,15}$/;
+const usernameValidation = (username) => usernameRegex.test(username);
+const passwordRegex = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,}$/;
+const passwordValidation = (password) => passwordRegex.test(password);
+const signUpMSG = {
+  nullInput: '회원가입에 필요한 데이터일부가 누락되었습니다.',
+  inValidLoginID: 'ID는 영소문자로 시작하는 6~15자의 영소문자 또는 숫자 여야 합니다.',
+  inValidUsername: '유저 이름은 공백없이 1~15자여야 합니다.',
+  inValidPassword:
+    '비밀번호는 8자 이상 영대문자, 영소문자, 숫자, 특수문자를 최소 1개씩 포함하여야합니다.',
+  usedID: '이미 사용중인 ID 입니다.',
+  success: '회원가입에 성공했습니다.',
+};
 
 const signUp = async (req: Request, res: Response, next: NextFunction) => {
   const { loginID, username, password } = req.body;
 
   try {
     if (![loginID, username, password].every((data) => nullCheck(data)))
-      return res.status(400).send('회원가입에 필요한 데이터일부가 누락되었습니다.');
+      return res.status(400).send(signUpMSG.nullInput);
+
+    const isValidLoginID = loginIDValidation(loginID);
+    if (!isValidLoginID) return res.status(400).send(signUpMSG.inValidLoginID);
+
+    const isValidUsername = usernameValidation(username);
+    if (!isValidUsername) return res.status(400).send(signUpMSG.inValidUsername);
+
+    const isValidPassword = passwordValidation(password);
+    if (!isValidPassword) return res.status(400).send(signUpMSG.inValidPassword);
 
     const isUsedID = await userRepository.findOne({ where: { loginID: loginID } });
-    if (isUsedID) return res.status(400).send('이미 사용중인 ID 입니다.');
+    if (isUsedID) return res.status(400).send(signUpMSG.usedID);
 
     const newUser = new User();
     newUser.loginID = loginID;
@@ -28,7 +55,7 @@ const signUp = async (req: Request, res: Response, next: NextFunction) => {
     newUser.password = await hash(password, saltRounds);
     await userRepository.save(newUser);
 
-    return res.status(200).send('회원가입에 성공했습니다.');
+    return res.status(200).send(signUpMSG.success);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#48 
## What did you do?
회원가입 API 유효성 검사 기능을 추가했습니다.

아이디는 영소문자로 시작하는 영소문자,숫자 조합 6~15자로 제한.

이름은 공백없이 1~15자로 제한.

비밀번호는 영대문자, 영소문자, 특수문자 각각 최소 1자 포함한 8자 이상으로 제한.
<!--무엇을 하셨나요?-->
- [x]  회원가입 API 유효성 검사 기능 추가
- [x]  응답 메시지 별도 객체로 분리

## 레퍼런스
<!--참고한 자료가 있나요?-->
[자주 사용하는 정규 표현식 모음](https://blogpack.tistory.com/560)
