### PR TITLE
그룹생성 시 디폴트 채널 2개 생성, 유저의 전체 그룹조회 시 채널도 조회 가능

### DIFF
--- a/server/src/controller/group.controller.ts
+++ b/server/src/controller/group.controller.ts
@@ -1,8 +1,16 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { groupMemberRepository, groupRepository, userRepository } from '../db';
+import {
+  groupMemberRepository,
+  groupRepository,
+  meetingChannelRepository,
+  textChannelRepository,
+  userRepository,
+} from '../db';
 import { Group } from '../entity/group.entity';
 import { GroupMember } from '../entity/groupmember.entity';
+import { MeetingChannel } from '../entity/meetingchannel.entity';
+import { TextChannel } from '../entity/textchannel.entity';
 
 const nullCheck = (data) => data !== undefined && data !== null && data !== '';
 const encodeBase64 = (str: string): string => Buffer.from(str, 'binary').toString('base64');
@@ -30,6 +38,16 @@ const createGroup = async (req: Request, res: Response, next: NextFunction) => {
     newRelation.user = leader;
     newRelation.lastAccessTime = now;
     await groupMemberRepository.save(newRelation);
+
+    const newMeetingChannel = new MeetingChannel();
+    newMeetingChannel.group = newGroup;
+    newMeetingChannel.name = 'default';
+    await meetingChannelRepository.save(newMeetingChannel);
+
+    const newTextChannel = new TextChannel();
+    newTextChannel.group = newGroup;
+    newTextChannel.name = 'default';
+    await textChannelRepository.save(newTextChannel);
 
     return res.status(200).json({ code: newGroup.code });
   } catch (error) {

--- a/server/src/controller/group.controller.ts
+++ b/server/src/controller/group.controller.ts
@@ -61,12 +61,7 @@ const getGroupMembers = async (req: Request, res: Response, next: NextFunction) 
     const group = await groupRepository.findOne({ where: { id: id } });
     if (!group) return res.status(400).send('존재하지 않는 그룹 아이디입니다.');
 
-    const members = await groupMemberRepository
-      .createQueryBuilder('group_member')
-      .where('group_member.groupId = :id', { id: id })
-      .leftJoinAndSelect('group_member.user', 'user')
-      .select(['group_member.lastAccessTime', 'user.id', 'user.username', 'user.thumbnail'])
-      .getMany();
+    const members = await groupMemberRepository.findUsersByGroupID(group.id);
 
     res.status(200).json({ members });
   } catch (error) {

--- a/server/src/controller/user.controller.ts
+++ b/server/src/controller/user.controller.ts
@@ -102,20 +102,7 @@ const getUserGroups = async (req: Request, res: Response, next: NextFunction) =>
     const userdata = await userRepository.findByID(userID);
     if (!userdata) return res.status(400).send('존재하지 않는 유저입니다.');
 
-    const groups = await groupMemberRepository
-      .createQueryBuilder('group_member')
-      .where('group_member.userId = :id', { id: userID })
-      .leftJoinAndSelect('group_member.group', 'group')
-      .select([
-        'group_member.lastAccessTime',
-        'group.id',
-        'group.name',
-        'group.thumbnail',
-        'group.code',
-      ])
-      .leftJoinAndSelect('group.meetingChannels', 'meetingChannels')
-      .leftJoinAndSelect('group.textChannels', 'textChannels')
-      .getMany();
+    const groups = await groupMemberRepository.findGroupsByUserID(userID);
 
     return res.status(200).json({ groups });
   } catch (error) {

--- a/server/src/controller/user.controller.ts
+++ b/server/src/controller/user.controller.ts
@@ -113,6 +113,8 @@ const getUserGroups = async (req: Request, res: Response, next: NextFunction) =>
         'group.thumbnail',
         'group.code',
       ])
+      .leftJoinAndSelect('group.meetingChannels', 'meetingChannels')
+      .leftJoinAndSelect('group.textChannels', 'textChannels')
       .getMany();
 
     return res.status(200).json({ groups });

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -26,6 +26,8 @@ export let userRepository: UserRepository;
 export let sessionRepository;
 export let groupRepository: Repository<Group>;
 export let groupMemberRepository: Repository<GroupMember>;
+export let textChannelRepository: Repository<TextChannel>;
+export let meetingChannelRepository: Repository<MeetingChannel>;
 
 const connectDB = async () => {
   connection = await createConnection({
@@ -60,4 +62,6 @@ export const initORM = async () => {
   sessionRepository = await getRepository(Session);
   groupRepository = await getRepository(Group);
   groupMemberRepository = await getRepository(GroupMember);
+  textChannelRepository = await getRepository(TextChannel);
+  meetingChannelRepository = await getRepository(MeetingChannel);
 };

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -18,6 +18,7 @@ import { Group } from '../entity/group.entity';
 import { File } from '../entity/file.entity';
 import { Session } from '../entity/session.entity';
 import { UserRepository } from './repository/user.repository';
+import { GroupMemberRepository } from './repository/groupmember.repository';
 
 dotenv.config();
 
@@ -25,7 +26,7 @@ export let connection: Connection;
 export let userRepository: UserRepository;
 export let sessionRepository;
 export let groupRepository: Repository<Group>;
-export let groupMemberRepository: Repository<GroupMember>;
+export let groupMemberRepository: GroupMemberRepository;
 export let textChannelRepository: Repository<TextChannel>;
 export let meetingChannelRepository: Repository<MeetingChannel>;
 
@@ -61,7 +62,7 @@ export const initORM = async () => {
   userRepository = await getCustomRepository(UserRepository);
   sessionRepository = await getRepository(Session);
   groupRepository = await getRepository(Group);
-  groupMemberRepository = await getRepository(GroupMember);
+  groupMemberRepository = await getCustomRepository(GroupMemberRepository);
   textChannelRepository = await getRepository(TextChannel);
   meetingChannelRepository = await getRepository(MeetingChannel);
 };

--- a/server/src/db/repository/groupmember.repository.ts
+++ b/server/src/db/repository/groupmember.repository.ts
@@ -1,0 +1,29 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { GroupMember } from '../../entity/groupmember.entity';
+
+@EntityRepository(GroupMember)
+export class GroupMemberRepository extends Repository<GroupMember> {
+  findGroupsByUserID(userID: number) {
+    return this.createQueryBuilder('group_member')
+      .where('group_member.userId = :id', { id: userID })
+      .leftJoinAndSelect('group_member.group', 'group')
+      .select([
+        'group_member.lastAccessTime',
+        'group.id',
+        'group.name',
+        'group.thumbnail',
+        'group.code',
+      ])
+      .leftJoinAndSelect('group.meetingChannels', 'meetingChannels')
+      .leftJoinAndSelect('group.textChannels', 'textChannels')
+      .getMany();
+  }
+
+  findUsersByGroupID(groupID: number) {
+    return this.createQueryBuilder('group_member')
+      .where('group_member.groupId = :id', { id: groupID })
+      .leftJoinAndSelect('group_member.user', 'user')
+      .select(['group_member.lastAccessTime', 'user.id', 'user.username', 'user.thumbnail'])
+      .getMany();
+  }
+}

--- a/server/src/entity/meetingchannel.entity.ts
+++ b/server/src/entity/meetingchannel.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToOne } from 'typeorm';
 
 import { Base } from './base.entity';
 import { Group } from './group.entity';
@@ -7,4 +7,7 @@ import { Group } from './group.entity';
 export class MeetingChannel extends Base {
   @ManyToOne((type) => Group, (group) => group.meetingChannels)
   group: Group;
+
+  @Column()
+  name: string;
 }

--- a/server/src/entity/textchannel.entity.ts
+++ b/server/src/entity/textchannel.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, OneToMany, OneToOne } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 
 import { Base } from './base.entity';
 import { Group } from './group.entity';
@@ -11,4 +11,7 @@ export class TextChannel extends Base {
 
   @ManyToOne((type) => Group, (group) => group.textChannels)
   group: Group;
+
+  @Column()
+  name: string;
 }


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#60 

## What did you do?

<!--무엇을 하셨나요?-->
- [x]  그룹생성 시 디폴트 채널 2개 생성
- [x] 유저의 전체 그룹조회 시 채널도 조회 가능
- [x] <strong>!!중요!!</strong> 엔티티 수정


## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
- 처음에 엔티티를 생성할 때 채널들에게 이름 속성을 넣어주지 않은 걸 지금 발견했습니다ㅜㅜ
- 이 브랜치가 dev에 머지되고 .. 여러분들이 pull 받게 된다면.. 반드시 데이터베이스를 지웠다가 다시 create하셔야 합니다ㅜㅜ
- 엔티티를 만들 때 별도의 마이그레이션 파일을 만들지 않았어서 일단 지금은 데이터베이스를 싹 밀고 다시 만드는 게 최선일 것 같습니다
- 그렇지만 더 좋은 방법이 있다면 언제든지 알려주세요!!!
