### PR TITLE
user/signup API 테스트 작성 및 코드 수정

### DIFF
--- a/server/src/controller/user.controller.test.ts
+++ b/server/src/controller/user.controller.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 
 import { appInit } from '..';
 import { userRepository } from '../db';
+import { signInMSG } from './user.controller';
 
 let app;
 
@@ -10,15 +11,16 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await userRepository.delete({ loginID: 'unit' });
+  await userRepository.delete({ loginID: 'unittest' });
 });
 
 describe('POST /user/signup', () => {
+  const testUserData = { loginID: 'unittest', username: 'unittest', password: 'Unittest01!' };
   context('회원가입이 정상적으로 진행되었을 때(상태코드 200)', () => {
     it('회원가입 성공 메시지를 반환', (done) => {
       request(app)
         .post('/api/user/signup')
-        .send({ loginID: 'unit', username: 'unit', password: 'unit' })
+        .send(testUserData)
         .expect(200)
         .end((err, res) => {
           if (err) return done(err);
@@ -28,10 +30,10 @@ describe('POST /user/signup', () => {
     });
   });
   context('회원가입에 실패했을 때(상태코드 400)', () => {
-    it('아이디가 중복된 경우.', (done) => {
+    it('아이디가 중복된 경우', (done) => {
       request(app)
         .post('/api/user/signup')
-        .send({ loginID: 'unit', username: 'unit', password: 'unit' })
+        .send(testUserData)
         .expect(400)
         .end((err, res) => {
           if (err) return done(err);
@@ -39,5 +41,36 @@ describe('POST /user/signup', () => {
           done();
         });
     });
+  });
+});
+
+describe('POST /user/signin', () => {
+  const testLoginData = { loginID: 'unittest', password: 'Unittest01!' };
+  context('로그인이 정상적으로 진행되었을 때(상태코드 200)', () => {
+    it('로그인 성공 메시지를 반환', (done) => {
+      request(app)
+        .post('/api/user/signin')
+        .send(testLoginData)
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res.text).toBe(signInMSG.success);
+          done();
+        });
+    });
+  });
+  context('로그인에 실패한 경우(상태코드 400)', () => {
+    it('패스워드가 틀린 경우', (done) => {
+      request(app)
+        .post('/api/user/signin')
+        .send({ ...testLoginData, password: 'wrong' })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res.text).toBe(signInMSG.wrongPassword);
+          done();
+        });
+    });
+    it('존재하지 않는 유저인 경우', () => {});
   });
 });

--- a/server/src/controller/user.controller.test.ts
+++ b/server/src/controller/user.controller.test.ts
@@ -71,6 +71,16 @@ describe('POST /user/signin', () => {
           done();
         });
     });
-    it('존재하지 않는 유저인 경우', () => {});
+    it('존재하지 않는 유저인 경우', (done) => {
+      request(app)
+        .post('/api/user/signin')
+        .send({ ...testLoginData, loginID: 'wrong' })
+        .expect(400)
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res.text).toBe(signInMSG.userNotFound);
+          done();
+        });
+    });
   });
 });

--- a/server/src/controller/user.controller.ts
+++ b/server/src/controller/user.controller.ts
@@ -21,7 +21,7 @@ const usernameValidation = (username) => usernameRegex.test(username);
 const passwordRegex = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,}$/;
 const passwordValidation = (password) => passwordRegex.test(password);
 export const signUpMSG = {
-  nullInput: '회원가입에 필요한 데이터일부가 누락되었습니다.',
+  nullInput: '회원가입에 필요한 데이터를 모두 입력해주세요.',
   inValidLoginID: 'ID는 영소문자로 시작하는 6~15자의 영소문자 또는 숫자 여야 합니다.',
   inValidUsername: '유저 이름은 공백없이 1~15자여야 합니다.',
   inValidPassword:

--- a/server/src/controller/user.controller.ts
+++ b/server/src/controller/user.controller.ts
@@ -20,7 +20,7 @@ const usernameRegex = /^[^\s]{1,15}$/;
 const usernameValidation = (username) => usernameRegex.test(username);
 const passwordRegex = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,}$/;
 const passwordValidation = (password) => passwordRegex.test(password);
-const signUpMSG = {
+export const signUpMSG = {
   nullInput: '회원가입에 필요한 데이터일부가 누락되었습니다.',
   inValidLoginID: 'ID는 영소문자로 시작하는 6~15자의 영소문자 또는 숫자 여야 합니다.',
   inValidUsername: '유저 이름은 공백없이 1~15자여야 합니다.',
@@ -28,6 +28,11 @@ const signUpMSG = {
     '비밀번호는 8자 이상 영대문자, 영소문자, 숫자, 특수문자를 최소 1개씩 포함하여야합니다.',
   usedID: '이미 사용중인 ID 입니다.',
   success: '회원가입에 성공했습니다.',
+};
+export const signInMSG = {
+  userNotFound: '존재하지 않는 회원입니다.',
+  wrongPassword: '비밀번호가 올바르지 않습니다.',
+  success: '로그인 성공!',
 };
 
 const signUp = async (req: Request, res: Response, next: NextFunction) => {
@@ -66,13 +71,13 @@ const signIn = async (req: Request, res: Response, next: NextFunction) => {
 
   try {
     const user = await userRepository.findOne({ where: { loginID: loginID } });
-    if (!user) return res.status(400).send('존재하지 않는 회원입니다.');
+    if (!user) return res.status(400).send(signInMSG.userNotFound);
 
     const isValidPassword = await compare(password, user.password);
-    if (!isValidPassword) return res.status(400).send('비밀번호가 올바르지 않습니다.');
+    if (!isValidPassword) return res.status(400).send(signInMSG.wrongPassword);
 
     req.session.userID = user.id;
-    return res.status(200).send('로그인 성공!');
+    return res.status(200).send(signInMSG.success);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#47 
## What did you do?

<!--무엇을 하셨나요?-->
- [x] /user/signin API 응답 메시지  signInMSG 로 분리
- [x] /user/signin API 엔드포인트 테스트 작성 
- [x] signUpMSG.nullInput '회원가입에 필요한 데이터일부가 누락되었습니다.' => '회원가입에 필요한 데이터를 모두 입력해주세요.'

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
테스트 작성하면서 코드들을 살펴보니 개선해야 할 점이 매우 많았습니다. ㅠㅠ
그중 하나는 현재 유효하지 않은 데이터가 여러개 존재할 때도 하나만 확인 할 수 있다는 것입니다.
loginID, username, password가 다 유효하지 않아도 제일 먼저 검사하는 loginID에 대해서만 알 수 있고, loginID를 고쳐서 다시 요청하면 그제서야 username도 유효하지 않다는 것을 알게됩니다.
이는 사용자 경험을 크게 저해하기 때문에 수정이 시급합니다.
이를 해결하기 위해 API 응답 형식을 바꿔야 할 것 같습니다.
디스코드의 경우 어떻게 처리했는지 확인해 보았는데 아래와 같이 각 입력 항목에 대한 메시지를 JSON 형식으로 담아 반환합니다.
![디코회원가입응답](https://user-images.githubusercontent.com/77329061/139914719-ce0505a5-f909-466f-8be5-bfd67f294ecb.png)
![로그인, 회원가입 에러 응답](https://user-images.githubusercontent.com/77329061/139914721-b65d1173-3bee-427d-9771-269936d27652.png)

