### PR TITLE
Fix : chatListRef.current 가 null 인 경우 return 하도록 수정

### DIFF
--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -47,7 +47,8 @@ function Chat() {
         chats?.unshift(chat);
         return chats;
       });
-      const { scrollTop, clientHeight, scrollHeight } = chatListRef.current as HTMLDivElement;
+      if (chatListRef.current === null) return;
+      const { scrollTop, clientHeight, scrollHeight } = chatListRef.current;
       if (scrollHeight - (scrollTop + clientHeight) < THRESHOLD) scrollToBottom();
     },
     [chats, mutate]


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#104 
## What did you do?

<!--무엇을 하셨나요?-->
- [x] chatListRef.current 가 null일때 예외처리를 해주지 않아 발생한 버그 수정  

## 고민한 점, 질문거리
호다닥 고쳤습니다!
