### PR TITLE
좋아요 API 만들기, 채팅 조회 API 응답 수정하기

### DIFF
--- a/server/src/controller/channel.controller.ts
+++ b/server/src/controller/channel.controller.ts
@@ -13,9 +13,10 @@ export const createChatMSG = {
 
 const getChat = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const { userID } = req.session;
     const { chattingChannelID } = req.params;
     const page = Number(req.query.page);
-    const chats = await chatRepository.findChatsByPages(chattingChannelID, page);
+    const chats = await chatRepository.findChatsByPages(chattingChannelID, page, userID);
 
     return res.status(200).json(chats);
   } catch (error) {

--- a/server/src/controller/chat.controller.ts
+++ b/server/src/controller/chat.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { userRepository, chatRepository, threadRepository } from '../db';
+import { userRepository, chatRepository, threadRepository, reactionRepository } from '../db';
 
 import { Thread } from '../entity/thread.entity';
 
@@ -11,13 +11,48 @@ export const createChatMSG = {
   success: '스레드 전송 성공!',
 };
 
+const handleReactionMSG = {
+  userNotFound: '존재하지 않는 사용자 입니다.',
+  chatNotFound: '존재하지 않는 텍스트 입니다.',
+  deleteReactionSuccess: '좋아요 지우기 성공!',
+  addReactionSuccess: '좋아요 만들기 성공!',
+};
+
+const handleReaction = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { chatID } = req.params;
+    const { userID } = req.session;
+
+    const user = await userRepository.findOne({ where: { id: userID } });
+    const chat = await chatRepository.findOne({ where: { id: chatID } });
+    if (!user) return res.status(400).send(handleReactionMSG.userNotFound);
+    if (!chat) return res.status(400).send(handleReactionMSG.chatNotFound);
+
+    const reaction = await reactionRepository.findOne({ where: { user: user, chat: chat } });
+
+    if (!reaction) {
+      await reactionRepository.insert({ user: user, chat: chat });
+      chat.reactionsCount += 1;
+      await chatRepository.save(chat);
+      res.status(200).send(handleReactionMSG.addReactionSuccess);
+    } else {
+      await reactionRepository.remove(reaction);
+      chat.reactionsCount -= 1;
+      await chatRepository.save(chat);
+      res.status(200).send(handleReactionMSG.deleteReactionSuccess);
+    }
+  } catch (error) {
+    next(error);
+  }
+};
+
 const createThread = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { content } = req.body;
-    const { id } = req.params;
+    const { chatID } = req.params;
     const { userID } = req.session;
     const user = await userRepository.findOne({ where: { id: userID } });
-    const chat = await chatRepository.findOne({ where: { id: id } });
+    const chat = await chatRepository.findOne({ where: { id: chatID } });
 
     if (!user) return res.status(400).send(createChatMSG.userNotFound);
     if (!chat) return res.status(400).send(createChatMSG.chatNotFound);
@@ -36,4 +71,4 @@ const createThread = async (req: Request, res: Response, next: NextFunction) => 
   }
 };
 
-export default { createThread };
+export default { createThread, handleReaction };

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -31,6 +31,7 @@ export let chattingChannelRepository: Repository<ChattingChannel>;
 export let meetingChannelRepository: Repository<MeetingChannel>;
 export let chatRepository: ChatRepository;
 export let threadRepository: Repository<Thread>;
+export let reactionRepository: Repository<Reaction>;
 
 const connectDB = async () => {
   connection = await createConnection({
@@ -69,4 +70,5 @@ export const initORM = async () => {
   meetingChannelRepository = await getRepository(MeetingChannel);
   chatRepository = await getCustomRepository(ChatRepository);
   threadRepository = await getRepository(Thread);
+  reactionRepository = await getRepository(Reaction);
 };

--- a/server/src/db/repository/chat.repository.ts
+++ b/server/src/db/repository/chat.repository.ts
@@ -11,7 +11,6 @@ export class ChatRepository extends Repository<Chat> {
       .leftJoinAndSelect('chat.reactions', 'reaction', 'reaction.user = :userID', {
         userID: userID,
       })
-      .addSelect('reaction.id is NOT NULL', 'isReactioned')
       .select([
         'chat.id',
         'chat.content',

--- a/server/src/db/repository/chat.repository.ts
+++ b/server/src/db/repository/chat.repository.ts
@@ -3,19 +3,25 @@ import { Chat } from '../../entity/chat.entity';
 
 @EntityRepository(Chat)
 export class ChatRepository extends Repository<Chat> {
-  findChatsByPages(chattingChannelID: string, page: number) {
+  findChatsByPages(chattingChannelID: string, page: number, userID: number) {
     const chatPerPage = 20;
     return this.createQueryBuilder('chat')
       .where('chat.chattingChannel = :id', { id: chattingChannelID })
       .leftJoinAndSelect('chat.user', 'user')
+      .leftJoinAndSelect('chat.reactions', 'reaction', 'reaction.user = :userID', {
+        userID: userID,
+      })
+      .addSelect('reaction.id is NOT NULL', 'isReactioned')
       .select([
         'chat.id',
         'chat.content',
         'chat.createdAt',
         'chat.updatedAt',
+        'chat.reactionsCount',
         'user.id',
         'user.username',
         'user.thumbnail',
+        'reaction.id',
       ])
       .orderBy('chat.createdAt', 'DESC')
       .skip(chatPerPage * (page - 1))

--- a/server/src/router/api/chat.router.ts
+++ b/server/src/router/api/chat.router.ts
@@ -3,4 +3,13 @@ import chatController from '../../controller/chat.controller';
 import { accessControl } from '../../util';
 export const chatRouter = Router();
 
-chatRouter.post('/:id/thread/create', accessControl({ signIn: true }), chatController.createThread);
+chatRouter.post(
+  '/:chatID/thread/create',
+  accessControl({ signIn: true }),
+  chatController.createThread,
+);
+chatRouter.post(
+  '/:chatID/reaction',
+  accessControl({ signIn: true }),
+  chatController.handleReaction,
+);


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#112 

## What did you do?

<!--무엇을 하셨나요?-->
- [x] **좋아요 API 만들기**
	`api/chat/2/reaction`
	좋아요가 이미 있으면 (1) 그 좋아요 관계를 삭제하고 (2) 좋아요 숫자를 하나 줄인다
	좋아요가 없으면 (1) 좋아요 관계를 하나 만들고 (2) 좋아요 숫자를 하나 늘린다
- [x] **채팅 시 좋아요 조회 가능하게 만들기**
	좋아요가 없는 채팅에 대해서는 다음과 같이 reaction 배열이 비어서 응답이 온다
	```json
    {
        "id": 2,
        "createdAt": "2021-11-08T08:21:54.703Z",
        "updatedAt": "2021-11-08T09:26:05.000Z",
        "content": "eee",
        "reactionsCount": 0,
        "user": {
            "id": 1,
            "username": "aa",
            "thumbnail": null
        },
        "reactions": []
    }
	```
	좋아요가 있는 채팅에 대해서는 다음과 같이 reaction 배열에 뭔가 들어서 응답이 온다
	```json
    {
        "id": 2,
        "createdAt": "2021-11-08T08:21:54.703Z",
        "updatedAt": "2021-11-08T09:30:40.000Z",
        "content": "eee",
        "reactionsCount": 1,
        "user": {
            "id": 1,
            "username": "aa",
            "thumbnail": null
        },
        "reactions": [
            {
                "id": 9
            }
        ]
    }
	```


## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
좋아요 배열이 저렇게 나온다는 점이 너무나 고민스럽다 ...
true 아님 false로 오면 좋겠는데
근데 그 처리를 프론트가 해도 괜찮지 않을까? 싶다

