### PR TITLE
Feature/#124 새로고침시 원래 그룹/채널 복귀

### DIFF
--- a/client/src/api/STATUS_CODES.ts
+++ b/client/src/api/STATUS_CODES.ts
@@ -1,0 +1,4 @@
+export enum STATUS_CODES {
+  OK = 200,
+  BAD_REQUEST = 400,
+}

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -51,7 +51,7 @@ function Chat() {
       const { scrollTop, clientHeight, scrollHeight } = chatListRef.current;
       if (scrollHeight - (scrollTop + clientHeight) < THRESHOLD) scrollToBottom();
     },
-    [chats, mutate]
+    [mutate]
   );
 
   useEffect(() => {

--- a/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
+++ b/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
@@ -19,7 +19,7 @@ function ChannelListItem({ channelType, id, name }: Props) {
   const history = useHistory();
   const dispatch = useDispatch();
   const joinChannel = () => {
-    history.push(`/Main/group/${selectedGroup?.id}/${channelType}/${id}`);
+    history.push(`/main?group=${selectedGroup?.id}&type=${channelType}&id=${id}`);
     socket.emit('leaveChannel', selectedChannel.type + selectedChannel.id);
     socket.emit('joinChannel', channelType + id);
     dispatch(setSelectedChannel({ type: channelType, id, name }));
@@ -31,7 +31,7 @@ function ChannelListItem({ channelType, id, name }: Props) {
         <img src={'/icons/' + channelType + 'Channel.png'} alt={channelType + 'Channel'} />
         <p>{name}</p>
       </div>
-      <img src='/icons/delete.png' alt='deleteChannel' />
+      <img src="/icons/delete.png" alt="deleteChannel" />
     </ListItem>
   );
 }

--- a/client/src/components/SideBar/GroupNav/index.tsx
+++ b/client/src/components/SideBar/GroupNav/index.tsx
@@ -24,7 +24,7 @@ function GroupNav() {
   };
 
   const selectGroup = (group: any) => () => {
-    history.push(`/Main/group/${group.id}`);
+    history.push(`/main?group=${group.id}`);
     socket.emit('leaveChannel', type + id);
     dispatch(setSelectedChannel({ type: '', id: null, name: '' }));
     dispatch(setSelectedGroup(group));

--- a/client/src/components/common/RestrictedRoute/index.tsx
+++ b/client/src/components/common/RestrictedRoute/index.tsx
@@ -3,7 +3,6 @@ import { Route, RouteProps } from 'react-router-dom';
 import { useAccessControl } from '../../../hooks/useAccessControl';
 
 interface Props extends RouteProps {
-  // component: any;
   signIn: boolean;
   redirectPath: string;
 }

--- a/client/src/components/common/RestrictedRoute/index.tsx
+++ b/client/src/components/common/RestrictedRoute/index.tsx
@@ -1,25 +1,23 @@
 import React from 'react';
-import useSWR from 'swr';
-import { API_URL } from '../../../api/API_URL';
-import { getFetcher } from '../../../util/fetcher';
-import { Route, Redirect, RouteProps } from 'react-router-dom';
+import { Route, RouteProps } from 'react-router-dom';
+import { useAccessControl } from '../../../hooks/useAccessControl';
 
 interface Props extends RouteProps {
+  // component: any;
   signIn: boolean;
   redirectPath: string;
 }
 
 function RestrictedRoute({ component: Component, signIn, redirectPath, ...rest }: Props) {
-  const { data: userdata } = useSWR(API_URL.user.getUserdata, getFetcher);
   if (!Component) return null;
-  const accessible = (signIn && userdata) || (!signIn && !userdata);
 
-  return (
-    <Route
-      {...rest}
-      render={(props) => (accessible ? <Component {...props} /> : <Redirect to={redirectPath} />)}
-    />
-  );
+  const RestrictedComponent = (props: any) => {
+    useAccessControl({ signIn, redirectPath });
+
+    return <Component {...props} />;
+  };
+
+  return <Route {...rest} component={RestrictedComponent} />;
 }
 
 export default RestrictedRoute;

--- a/client/src/hooks/useAccessControl.ts
+++ b/client/src/hooks/useAccessControl.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useHistory } from 'react-router';
+import { API_URL } from '../api/API_URL';
+import { STATUS_CODES } from '../api/STATUS_CODES';
+
+export const useAccessControl = ({
+  signIn = true,
+  redirectPath = '/',
+}: {
+  signIn: boolean;
+  redirectPath: string;
+}) => {
+  const history = useHistory();
+
+  useEffect(() => {
+    fetch(API_URL.user.getUserdata).then(({ status }) => {
+      const accessible =
+        (signIn && status === STATUS_CODES.OK) || (!signIn && status >= STATUS_CODES.BAD_REQUEST);
+      if (!accessible) history.push(redirectPath);
+    });
+  });
+};

--- a/client/src/hooks/useGroups.ts
+++ b/client/src/hooks/useGroups.ts
@@ -17,7 +17,7 @@ const getGroupsFetcher = async (url: string) => {
 };
 
 export const useGroups = () => {
-  const { data: groups, error, mutate } = useSWR(API_URL.user.getGroups, getGroupsFetcher);
+  const { data: groups, ...rest } = useSWR(API_URL.user.getGroups, getGroupsFetcher);
   const selectedGroup = useSelectedGroup();
   const dispatch = useDispatch();
 
@@ -30,5 +30,5 @@ export const useGroups = () => {
     dispatch(setSelectedGroup(updatedSelectedGroup));
   }, [groups, dispatch]);
 
-  return { groups, error, mutate };
+  return { groups, ...rest };
 };

--- a/client/src/hooks/useUserdata.ts
+++ b/client/src/hooks/useUserdata.ts
@@ -1,0 +1,9 @@
+import useSWR from 'swr';
+import { API_URL } from '../api/API_URL';
+import { getFetcher } from '../util/fetcher';
+
+export const useUserdata = () => {
+  const { data: userdata, ...rest } = useSWR(API_URL.user.getUserdata, getFetcher);
+
+  return { userdata, ...rest };
+};

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -1,12 +1,45 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import ChannelHeader from '../../components/ChannelHeader';
 import Chat from '../../components/Chat';
 import SideBar from '../../components/SideBar';
+import { useGroups } from '../../hooks/useGroups';
 import { useSelectedChannel } from '../../hooks/useSelectedChannel';
+import { useSelectedGroup } from '../../hooks/useSelectedGroup';
+import { setSelectedChannel } from '../../redux/selectedChannel/slice';
+import { setSelectedGroup } from '../../redux/selectedGroup/slice';
+import { getURLParams } from '../../util/getURLParams';
+import { socket } from '../../util/socket';
 import { Layout, MainWrapper } from './style';
 
 function Main() {
+  const { groups, isValidating } = useGroups();
+  const { groupID, channelType, channelID } = getURLParams();
+  const selectedGroup = useSelectedGroup();
   const selectedChannel = useSelectedChannel();
+  const dispatch = useDispatch();
+
+  useLayoutEffect(() => {
+    if (selectedGroup !== null) return;
+
+    const group = groups?.find((group: any) => group.id.toString() === groupID) ?? null;
+
+    if (group === null || groupID === null) return;
+
+    dispatch(setSelectedGroup(group));
+
+    if (selectedChannel.id !== null || channelID === null) return;
+
+    const { id, name } = group?.[
+      channelType === 'chatting' ? 'chattingChannels' : 'meetingChannels'
+    ].find((channel: any) => channel.id.toString() === channelID);
+
+    if (!id || !name) return;
+
+    socket.emit('joinChannel', channelType + id);
+    dispatch(setSelectedChannel({ id, name, type: channelType }));
+  }, [isValidating]);
+
   return (
     <Layout>
       <SideBar />

--- a/client/src/pages/SignIn/index.tsx
+++ b/client/src/pages/SignIn/index.tsx
@@ -14,8 +14,6 @@ import {
 import { SIGN_IN_ERROR_MESSAGE } from '../../util/message';
 import { checkLogin } from '../../util/checkResponse';
 import { tryLogin } from '../../util/api';
-import { mutate } from 'swr';
-import { API_URL } from '../../api/API_URL';
 
 const { ID_EMPTY_ERROR, PASSWORD_EMPTY_ERROR } = SIGN_IN_ERROR_MESSAGE;
 
@@ -46,7 +44,6 @@ function SignIn() {
 
     try {
       const loginResponse = await tryLogin(ID, password);
-      mutate(API_URL.user.getUserdata);
       setResponseState({ ...responseState, ...loginResponse });
     } catch (error) {
       console.log(error);

--- a/client/src/util/getURLParams.ts
+++ b/client/src/util/getURLParams.ts
@@ -1,0 +1,8 @@
+export const getURLParams = () => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const groupID = searchParams.get('group');
+  const channelType = searchParams.get('type');
+  const channelID = searchParams.get('id');
+
+  return { groupID, channelType, channelID };
+};


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#124 
## What did you do?
새로고침시 URL의 쿼리(SearchParams) 정보를 이용해 원래 선택되어 있던 그룹/채널로 복귀
기존 라우팅 방식의 경우 새로고침시 접근 허가된 페이지의 경우에도 한번 튕겨나갔다 복귀해 쿼리스트링이 날아가고, 유저 경험을 저해(다른 페이지를 잠시 보게됨)하는 문제가 있어 수정했습니다.

<!--무엇을 하셨나요?-->
- [x] 새로고침시 원래 그룹/채널로 복귀
- [x] 제한적 라우팅 로직 변경

## 팀원들에게 하고 싶은 말
너무 오래걸려서 미안합니다 ㅠㅠ

