### PR TITLE
Refactor : 소켓 joinChannel, leaveChannel emit 코드 분리

### DIFF
--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useUserDevice } from '../../../hooks/useUserDevice';
 import { VideoItem } from './style';
 
-function MeetButton() {
+function MeetVideo() {
   const myVideoRef = useRef<HTMLVideoElement>(null);
   const { mic, cam } = useUserDevice();
   const [myStream, setMyStream] = useState<MediaStream | null>(null);
@@ -36,9 +36,9 @@ function MeetButton() {
 
   return (
     <div>
-      <VideoItem autoPlay playsInline ref={myVideoRef}></VideoItem>
+      <VideoItem autoPlay playsInline ref={myVideoRef} muted></VideoItem>
     </div>
   );
 }
 
-export default MeetButton;
+export default MeetVideo;

--- a/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
+++ b/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
-import { useSelectedChannel } from '../../../../hooks/useSelectedChannel';
 import { useSelectedGroup } from '../../../../hooks/useSelectedGroup';
 import { setSelectedChannel } from '../../../../redux/selectedChannel/slice';
-import { socket } from '../../../../util/socket';
 import { ListItem } from './style';
 
 interface Props {
@@ -15,13 +13,10 @@ interface Props {
 
 function ChannelListItem({ channelType, id, name }: Props) {
   const selectedGroup = useSelectedGroup();
-  const selectedChannel = useSelectedChannel();
   const history = useHistory();
   const dispatch = useDispatch();
   const joinChannel = () => {
     history.push(`/main?group=${selectedGroup?.id}&type=${channelType}&id=${id}`);
-    socket.emit('leaveChannel', selectedChannel.type + selectedChannel.id);
-    socket.emit('joinChannel', channelType + id);
     dispatch(setSelectedChannel({ type: channelType, id, name }));
   };
 

--- a/client/src/components/SideBar/GroupNav/index.tsx
+++ b/client/src/components/SideBar/GroupNav/index.tsx
@@ -2,17 +2,14 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import { useGroups } from '../../../hooks/useGroups';
-import { useSelectedChannel } from '../../../hooks/useSelectedChannel';
 import { setSelectedChannel } from '../../../redux/selectedChannel/slice';
 import { setSelectedGroup } from '../../../redux/selectedGroup/slice';
 import GroupJoinModal from '../../Modal/GroupJoin';
 import { GroupListWrapper, GroupList, Group, GroupListDivider, AddGroupButton } from './style';
-import { socket } from '../../../util/socket';
 import { ModalController } from '../../../types/modal';
 
 function GroupNav() {
   const { groups } = useGroups();
-  const { id, type } = useSelectedChannel();
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -25,7 +22,6 @@ function GroupNav() {
 
   const selectGroup = (group: any) => () => {
     history.push(`/main?group=${group.id}`);
-    socket.emit('leaveChannel', type + id);
     dispatch(setSelectedChannel({ type: '', id: null, name: '' }));
     dispatch(setSelectedGroup(group));
   };

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -10,7 +10,6 @@ import { useSelectedGroup } from '../../hooks/useSelectedGroup';
 import { setSelectedChannel } from '../../redux/selectedChannel/slice';
 import { setSelectedGroup } from '../../redux/selectedGroup/slice';
 import { getURLParams } from '../../util/getURLParams';
-import { socket } from '../../util/socket';
 import { Layout, MainWrapper } from './style';
 
 function Main() {
@@ -37,7 +36,6 @@ function Main() {
 
     if (!id || !name) return;
 
-    socket.emit('joinChannel', channelType + id);
     dispatch(setSelectedChannel({ id, name, type: channelType }));
   }, [isValidating]);
 

--- a/client/src/util/socket.ts
+++ b/client/src/util/socket.ts
@@ -2,3 +2,13 @@ import { io } from 'socket.io-client';
 
 export const socket = io('/');
 socket.connect();
+
+const joinChannel = ({ channelType, id }: { channelType: 'chatting' | 'meeting'; id: number }) =>
+  socket.emit('joinChannel', channelType + id);
+
+const leaveChannel = ({ channelType, id }: { channelType: 'chatting' | 'meeting'; id: number }) =>
+  socket.emit('leaveChannel', channelType + id);
+
+const Socket = { socket, joinChannel, leaveChannel };
+
+export default Socket;


### PR DESCRIPTION
## What did you do?
chatting 채널 socket 접속에 대한 책임을 chat 컴포넌트만 갖도록 개선했습니다.
기존 channelListItem과 GroupNav 등에서 선택 채널이 변경될때마다 socket에 채널 join, leave 이벤트를 날려줬었는데
생각해보니 chat 채널에서 selectedChannel이 바뀔때마다 처리하고 클린업에서 나가도록 하면, 채팅에 관한 책임은 chat컴포넌트만 갖고 있을 수 있다고 생각해 변경했습니다!
기존 코드호환을 위해 socket 모듈의 socket(io를 담은 변수)는 그대로 export 하도록 두었습니다.

<!--무엇을 하셨나요?-->
- [x]  소켓 joinChannel, leaveChannel emit 코드 분리

