### PR TITLE
Feat/화상회의 레이아웃 잡기

### DIFF
--- a/client/src/components/Meet/MeetButton/index.tsx
+++ b/client/src/components/Meet/MeetButton/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { MeetButtonWrapper } from './style';
 
 function MeetButton() {
   return (
-    <>
+    <MeetButtonWrapper>
       <button>화면 공유</button>
       <button>통화 종료</button>
-    </>
+    </MeetButtonWrapper>
   );
 }
 

--- a/client/src/components/Meet/MeetButton/style.ts
+++ b/client/src/components/Meet/MeetButton/style.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import Colors from '../../../styles/Colors';
+
+const MeetButtonWrapper = styled.div`
+  position: sticky;
+  bottom: 20px;
+  width: 100%;
+  height: 10%;
+  display: flex;
+  justify-content: center;
+  & button {
+    width: 60px;
+    height: 60px;
+    border: none;
+    border-radius: 50%;
+    margin: 10px;
+    cursor: pointer;
+    &:first-child {
+      background-color: ${Colors.Gray1};
+    }
+    &:last-child {
+      background-color: ${Colors.DarkRed};
+    }
+  }
+`;
+
+export { MeetButtonWrapper };

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -3,7 +3,7 @@ import { useSelectedChannel } from '../../../hooks/useSelectedChannel';
 import { useUserdata } from '../../../hooks/useUserdata';
 import { useUserDevice } from '../../../hooks/useUserDevice';
 import Socket, { socket } from '../../../util/socket';
-import { VideoItem } from './style';
+import { MeetVideoWrapper, VideoItem } from './style';
 
 const pcConfig = {
   iceServers: [
@@ -26,10 +26,13 @@ function MeetVideo() {
   const { userdata } = useUserdata();
   const { id } = useSelectedChannel();
   const { mic, cam } = useUserDevice();
+  const videoWrapperRef = useRef<HTMLDivElement>(null);
   const myVideoRef = useRef<HTMLVideoElement>(null);
   const myStreamRef = useRef<MediaStream | null>(null);
   const [meetingMembers, setMeetingMembers] = useState<IMeetingUser[]>([]);
   const pcs = useRef<{ [socketID: string]: RTCPeerConnection }>({});
+
+  const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
 
   const getMyStream = async () => {
     try {
@@ -165,12 +168,12 @@ function MeetVideo() {
   }, [myStreamRef.current, mic, cam]);
 
   return (
-    <div>
+    <MeetVideoWrapper ref={videoWrapperRef} videoCount={videoCount || 0}>
       <VideoItem autoPlay playsInline ref={myVideoRef}></VideoItem>
       {meetingMembers.map((member) => (
         <OtherVideo member={member} />
       ))}
-    </div>
+    </MeetVideoWrapper>
   );
 }
 

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -1,8 +1,32 @@
 import styled from 'styled-components';
 
-const VideoItem = styled.video`
-  width: 300px;
-  height: 240px;
+interface IMeetVideoWrapper {
+  videoCount: number;
+}
+
+const MeetVideoWrapper = styled.div<IMeetVideoWrapper>`
+  margin: 0 auto;
+  display: grid;
+  width: 100%;
+  height: 90%;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  padding: 20px;
+  ${(props) =>
+    props.videoCount <= 2 ? 'grid-template-rows: 100%;' : 'grid-template-rows: 50% 50%;'}
+  ${(props) =>
+    props.videoCount <= 4
+      ? 'max-width: 900px; grid-template-columns: repeat(auto-fit, minmax(45%, 1fr));'
+      : 'max-width: 1500px; grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));'}
 `;
 
-export { VideoItem };
+const VideoItem = styled.video`
+  width: 100%;
+  max-width: 700px;
+  height: 100%;
+  justify-self: center;
+  align-self: center;
+`;
+
+export { MeetVideoWrapper, VideoItem };

--- a/client/src/components/Meet/index.tsx
+++ b/client/src/components/Meet/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import MeetVideo from './MeetVideo';
 import MeetButton from './MeetButton';
+import { MeetWrapper } from './style';
 
 function Meet() {
   return (
-    <div>
+    <MeetWrapper>
       <MeetVideo />
       <MeetButton />
-    </div>
+    </MeetWrapper>
   );
 }
 

--- a/client/src/components/Meet/style.ts
+++ b/client/src/components/Meet/style.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const MeetWrapper = styled.div`
+  width: 100%;
+  height: calc(100% - 50px);
+  padding: 10px;
+`;
+
+export { MeetWrapper };


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#149 

## What did you do?

<!--무엇을 하셨나요?-->
- [x] 화상회의 레이아웃 인원에 따라 변경되도록 구현
- [x] 화상회의 버튼 위치 조정
- [x] 브라우저 창 크기를 변경하면 화상 화면 크기가 변경되도록 구현

5명일때, 4명일때, 1명일때 사진 첨부해요
아 사진찍는데 너무 웃기다 ㅋㅋㅋ

![image](https://user-images.githubusercontent.com/73640737/141059808-03422e9e-2413-43eb-89cf-dc5cfcc144d3.png)

![image](https://user-images.githubusercontent.com/73640737/141059859-301e1e6c-eee6-4fbe-a479-0463a3d06627.png)

![image](https://user-images.githubusercontent.com/73640737/141059908-a03b103e-9e8f-4906-8992-36ee9d140247.png)


## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
화면을 엄청 줄이면 스크롤바가 생겨요 ㅠ
사용이 불편할정도로 줄이면 생기는거라서 일단은 pass...

## 레퍼런스
<!--참고한 자료가 있나요?-->

