### PR TITLE
Refactor/meet 캠/마이크 온오프 채널 입장 즉시 적용되지 않던 문제 수정 및 하드코딩... 처치

### DIFF
--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -155,10 +155,7 @@ function MeetVideo() {
       socket.off(MeetingEvent.LEAVE_MEMBER);
       socket.emit(MeetingEvent.LEAVE_MEETING);
 
-      meetingMembers.forEach((member) => {
-        if (!pcs.current[member.socketID]) return;
-        pcs.current[member.socketID].close();
-      });
+      Object.values(pcs.current).forEach((pc) => pc.close());
     };
   }, [id]);
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#147 
## What did you do?
난장판인 MeetVideo 컴포넌트를 조금 정리했습니다! 하지만 여전히 난장판입니다!

<!--무엇을 하셨나요?-->
- [x] 캠/마이크 온오프 채널 입장 즉시 적용되도록 수정
- [x] 소켓이벤트명 등 하드코딩 되어있던 코드들 enum 또는 상수 사용하도록 수정
- [x] 클린업 함수에서 peer connection을 닫기 위해 순회하는 코드 수정

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
처음부터 꼼꼼하게 했어야 했는데 죄송합니다...
소켓, RTC 등 코드 파일 분리는... 다른 PRdㅔ서 할게요...
그리고 현재 mic, cam 온오프 상태가 state로 관리되고 있어 변경시 리렌더링이 발생해 캠화면이 깜빡입니다.
또한 소켓 콜백에서 mic, cam의 최신 상태를 전달하려면 리렌더링때 마다 이벤트 리스너를 다시 붙여줘야 하는 문제가 있습니다. 따라서 useRef를 이용해 관리하도록 변경해야 할 것 같습니다.
