### PR TITLE
feat: 모달 열고 닫을 때 애니메이션 추가

### DIFF
--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ModalController, ModalData } from '../../types/modal';
 import { BottomRightButton, Bottom, Background, Wrapper, Title, SubTitle } from './style';
 
@@ -9,11 +9,20 @@ function Modal({
   props: ModalData;
   controller: ModalController;
 }) {
+  const [hidden, setHidden] = useState(false);
+
+  const hideModal = () => {
+    setHidden(() => true);
+    setTimeout(() => {
+      hide();
+    }, 300);
+  };
+
   return (
-    <Background onClick={hide}>
-      <Wrapper onClick={(e) => e.stopPropagation()}>
+    <Background onClick={hideModal} isHidden={hidden}>
+      <Wrapper onClick={(e) => e.stopPropagation()} isHidden={hidden}>
         <div style={{ textAlign: 'right' }}>
-          <img src="/icons/btn-close-modal.svg" alt="close modal" onClick={hide} />
+          <img src="/icons/btn-close-modal.svg" alt="close modal" onClick={hideModal} />
         </div>
         {title && <Title>{title}</Title>}
         {subTitle && <SubTitle>{subTitle}</SubTitle>}
@@ -23,7 +32,7 @@ function Modal({
             {previous !== null ? (
               <div onClick={previous}>이전</div>
             ) : (
-              <div onClick={hide}>닫기</div>
+              <div onClick={hideModal}>닫기</div>
             )}
             <BottomRightButton
               color={bottomRightButton.color}

--- a/client/src/components/Modal/style.ts
+++ b/client/src/components/Modal/style.ts
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 import Colors from '../../styles/Colors';
 
-const Wrapper = styled.div`
+interface IHideAnimation {
+  isHidden: boolean;
+}
+
+const Wrapper = styled.div<IHideAnimation>`
   background-color: ${Colors.White};
   padding: 20px;
   border-radius: 16px;
@@ -9,9 +13,34 @@ const Wrapper = styled.div`
   max-width: 400px;
   z-index: 999;
   min-width: 300px;
+  animation: ${(props) => (props.isHidden ? 'zoomOut' : 'zoomIn')} 0.3s forwards;
 
   & div {
     text-align: center;
+  }
+
+  @keyframes zoomIn {
+    0% {
+      transform: scale(0.6);
+    }
+    40% {
+      transform: scale(1);
+    }
+    60% {
+      transform: scale(1.05);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  @keyframes zoomOut {
+    0% {
+      transform: scale(1);
+    }
+    100% {
+      transform: scale(0.9);
+    }
   }
 `;
 
@@ -30,7 +59,7 @@ const Bottom = styled.div`
   margin-top: 16px;
 `;
 
-const Background = styled.div`
+const Background = styled.div<IHideAnimation>`
   position: absolute;
   top: 0;
   left: 0;
@@ -41,7 +70,25 @@ const Background = styled.div`
   align-items: center;
   background-color: rgba(0, 0, 0, 0.4);
   z-index: 998;
-  display: ${(props) => (props.hidden ? 'none' : 'flex')};
+  display: flex;
+  animation: ${(props) => (props.isHidden ? 'fadeOut' : 'fadeIn')} 0.3s forwards;
+  backdrop-filter: blur(1px);
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes fadeOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
 `;
 
 const Title = styled.h1`


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#115 

## What did you do?

<!--무엇을 하셨나요?-->
![2021-11-11 15 29 21](https://user-images.githubusercontent.com/48249505/141249246-1dc4e069-961e-4ddf-a5ed-57d0bd4fd812.gif)
- [x] 모달을 열고 닫을 때 애니메이션 추가
```tsx
  const [hidden, setHidden] = useState(false);

  const hideModal = () => {
    setHidden(() => true);
    setTimeout(() => {
      hide();
    }, 300);
  };
```
이렇게 hidden 상태가 바뀌고 애니메이션을 보여줄 시간을 setTimeout으로 벌어주었어

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
처음에 뜨는 건 mounted되었을 때 기본으로 뜨는거고 사라질 때는 hide()함수 호출을 살짝 바꿔준 거거든!
unmounted되었을 때도 저렇게 hidden 상태부터 바꾸고 사라졌으면 좋겠는데 useEffect()를 쓰니까 이상해서 지웠어..
history.push()가 일어나는 등 hide 호출 없이 unmount 되었을 때에는 애니메이션 없이 사라진다..
	예시 : 그룹 생성 이후 현재 있는 url이 바뀌어 모달이 사라지는 상황..
이 부분은 개선이 필요할 것 같아!!

## 레퍼런스
<!--참고한 자료가 있나요?-->

