### PR TITLE
Refactor : useAccessControl 개선

### DIFF
--- a/client/src/hooks/useAccessControl.ts
+++ b/client/src/hooks/useAccessControl.ts
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import { useHistory } from 'react-router';
-import { API_URL } from '../api/API_URL';
-import { STATUS_CODES } from '../api/STATUS_CODES';
 import { useUserdata } from './useUserdata';
 
 export const useAccessControl = ({
@@ -12,14 +10,11 @@ export const useAccessControl = ({
   redirectPath: string;
 }) => {
   const history = useHistory();
-  const { userdata } = useUserdata();
+  const { userdata, isValidating } = useUserdata();
 
   useEffect(() => {
-    if (userdata && signIn) return;
-    fetch(API_URL.user.getUserdata).then(({ status }) => {
-      const accessible =
-        (signIn && status === STATUS_CODES.OK) || (!signIn && status >= STATUS_CODES.BAD_REQUEST);
-      if (!accessible) history.push(redirectPath);
-    });
-  }, []);
+    if (isValidating) return;
+    const isAccessible = (signIn && userdata) || (!signIn && !userdata);
+    if (!isAccessible) history.push(redirectPath);
+  }, [isValidating, userdata, history, signIn, redirectPath]);
 };


### PR DESCRIPTION

## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#189 

## What did you do?

새로고침 했을 때 userdata가 로그인 되어있어도 undefined 초기값을 갖고 시작해서 튕겨나가는 문제가있었는데, 그것을 해결하고자 undefined인 경우 요청을 보내 확인하게 했더니... useUserdata에서도 요청을 보내고 useAccessControl에서도 똑같은 요청을 보내는 것이 아니겠습니까?
아무리 생각해도 굉장히 어색한 상황입니다. 같은 요청을 두번 보내다니!
이는 제가 생각이 짧아 useUserdata의 요청의 응답을 받은 후 로그인 여부를 판단하면 된다는 간단한 생각을 못했기 때문에 벌어진 일입니다.
예전에도 flag를 이용해 비동기 작업의 완료 여부를 확인 후 동작하는 코드를 작성해 봤음에도 이런 구린 코드를 작성했었다는 사실이 너무 부끄럽네요.
그래서! 제가 싼💩을 치우고자 개선했습니다!
useSWR은 현재 fetch 중인지(로딩중인지)를 알려주는 isValidating이라는 값을 반환해줍니다.
이 값이 true인 경우 아직 요청이 처리중인 경우이므로 return해 판단을 보류하고 isValidating이 false로 변경되면 그때 로그인 여부를 판단 하도록 수정했습니다!

<!--무엇을 하셨나요?-->
- [x]  isValidating을 활용해 useUserdata(useSWR)의 fetch가 완료된 후 로그인 여부를 판별하도록 변경함

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
이제 user 요청이 두배로 증식하지 않습니다!

## 레퍼런스
<!--참고한 자료가 있나요?-->
https://swr.vercel.app/ko/docs/options
