### PR TITLE
Fix : getMyStream 함수에서 getUserMedia로 스트림 생성에 실패했을 때 더미 스트림 생성

### DIFF
--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -30,8 +30,6 @@ enum MeetingEvent {
   LEAVE_MEETING = 'leaveMeeting',
 }
 
-const GET_MY_STREAM = 'getMyStream';
-
 interface IMeetingUser {
   socketID: string;
   loginID: string;
@@ -49,22 +47,21 @@ function MeetVideo() {
   const [myStream, setMyStream] = useState<MediaStream | null>(null);
   const [meetingMembers, setMeetingMembers] = useState<IMeetingUser[]>([]);
   const pcs = useRef<{ [socketID: string]: RTCPeerConnection }>({});
-
   const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
 
   const getMyStream = async () => {
+    let myStream;
     try {
-      const myStream = await navigator.mediaDevices.getUserMedia({
+      myStream = await navigator.mediaDevices.getUserMedia({
         audio: true,
         video: true,
       });
-      if (myVideoRef.current) myVideoRef.current.srcObject = myStream;
-      setMyStream(myStream);
     } catch (e) {
-      console.error(GET_MY_STREAM, e);
-      if (myVideoRef.current) myVideoRef.current.srcObject = myStream;
-      setMyStream(new MediaStream());
+      const canvas = document.createElement('canvas');
+      myStream = canvas.captureStream(0);
     }
+    if (myVideoRef.current) myVideoRef.current.srcObject = myStream;
+    setMyStream(myStream);
   };
 
   const createPeerConnection = useCallback(
@@ -172,7 +169,7 @@ function MeetVideo() {
 
       Object.values(pcs.current).forEach((pc) => pc.close());
     };
-  }, [id, userdata, myStream, createPeerConnection]);
+  }, [id, userdata, createPeerConnection]);
 
   useEffect(() => {
     if (myStream) {

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -20,11 +20,12 @@ function Main() {
   const dispatch = useDispatch();
 
   useLayoutEffect(() => {
-    if (selectedGroup !== null) return;
+    if (isValidating) return;
+    if (selectedGroup !== null || groupID === null) return;
 
     const group = groups?.find((group: any) => group.id.toString() === groupID) ?? null;
 
-    if (group === null || groupID === null) return;
+    if (group === null) return;
 
     dispatch(setSelectedGroup(group));
 


### PR DESCRIPTION
…통해 더미 스트림을 생성합니다

## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#190 
## What did you do?
원래 저희 코드에서는 캠이 없어 getUserMedia로 스트림 생성에 실패 했을 때 단순히 에러메시지를 콘솔에 찍어주기만하고 추가적인 조치는 취하지 않았었습니다.
그래서 스트림을 생성하지 못한 유저는 WebRTC 연결을 정상적으로 할 수 없었죠.
(들어가기 전부터 회의중이던 멤버들의 화면을 볼 수 없고, 이후에 들어온 유저들의 화면만 볼 수 있었습니다.)
오늘 피어세션에서 boostcam 캠퍼님들의 기술공유를 통해 canvas 엘리먼트를 이용해 더미 스트림을 만들 수 있다는 사실을 알게되었습니다.
이를 저희 프로젝트에도 적용해 getUserMedia로 스트림 생성에 실패 했을 때 catch문에서 더미 스트림을 만들어 주도록 수정했습니다. 이를 통해 크롱님이 리뷰에서 말씀하신 의미있는 에러처리가 되지 않았나 싶네요!

<!--무엇을 하셨나요?-->
- [x] getMyStream 함수에서 getUserMedia로 스트림 생성에 실패했을 때 더미 스트림 생성

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
다른 팀과 교류를 많이 하는 것이 좋겠습니다!

## 레퍼런스
<!--참고한 자료가 있나요?-->
boostcam 캠퍼분들 너무너무너무너무너무너무 감사합니다 ㅠㅠ
