### PR TITLE
로그아웃 기능을 구현 / 현재 접속인원 버그 수정

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -4,50 +4,50 @@ import { MemoryRouter } from 'react-router-dom';
 import App from './App';
 
 interface Path {
-  path:string
+  path: string;
 }
 
 describe('App은', () => {
-  const renderApp = ({ path } : Path) => {
+  const renderApp = ({ path }: Path) => {
     return render(
       <MemoryRouter initialEntries={[path]}>
         <App />
       </MemoryRouter>,
     );
-  }
+  };
 
   context('정상적으로 그려질 때', () => {
     it('전체를 감싸는 div(id=app)이 그려진다.', () => {
-      const { container } = renderApp({ path: '/' })
+      const { container } = renderApp({ path: '/' });
       expect(container.querySelector('.App')).toBeInTheDocument();
-    })
-  })
+    });
+  });
 
   context('path가 "/"이면', () => {
     it('로그인 페이지가 그려진다.', () => {
-      const { getByText } = renderApp({ path: '/' })
+      const { getByText } = renderApp({ path: '/' });
       expect(getByText('돌아오신 것을 환영해요!')).toBeInTheDocument();
-    })
+    });
 
-    it('가입하기 버튼을 누르면 회원가입 페이지로 이동한다.',() => {
-      const { getByText } = renderApp({ path: '/' })
-      fireEvent.click(getByText('가입하기'))
+    it('가입하기 버튼을 누르면 회원가입 페이지로 이동한다.', () => {
+      const { getByText } = renderApp({ path: '/' });
+      fireEvent.click(getByText('가입하기'));
       expect(getByText('계정 만들기')).toBeInTheDocument();
-    })
-  })
+    });
+  });
 
   context('path가 "/SignUp"이면', () => {
     it('회원가입 페이지가 그려진다.', () => {
-      const { getByText } = renderApp({ path: '/SignUp' })
+      const { getByText } = renderApp({ path: '/SignUp' });
       expect(getByText('계정 만들기')).toBeInTheDocument();
-    })
-  })
+    });
+  });
 
   context('path가 "/Main"이면', () => {
     it('text채널과 meeting채널을 보여준다.', () => {
       const { getByText } = renderApp({ path: '/Main' });
       expect(getByText('TEXT CHANNELS')).toBeInTheDocument();
       expect(getByText('MEETING CHANNELS')).toBeInTheDocument();
-    })
-  })
+    });
+  });
 });

--- a/client/src/api/API_URL.ts
+++ b/client/src/api/API_URL.ts
@@ -2,6 +2,7 @@ export const API_URL = {
   user: {
     getUserdata: '/api/user',
     getGroups: '/api/user/groups',
+    logout: '/api/user/signout',
   },
   channel: {
     postChat: (channelID: number) => `/api/channel/${channelID}/create`,

--- a/client/src/api/postLogout.ts
+++ b/client/src/api/postLogout.ts
@@ -1,0 +1,7 @@
+import { postFetchOptions } from '../util/fetchOptions';
+import { API_URL } from './API_URL';
+
+export const postLogout = async () => {
+  const response = await fetch(API_URL.user.logout, postFetchOptions({}));
+  return response.ok;
+};

--- a/client/src/components/ChannelHeader/index.tsx
+++ b/client/src/components/ChannelHeader/index.tsx
@@ -1,35 +1,47 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelectedChannel } from '../../hooks/useSelectedChannel';
+import { ModalController } from '../../types/modal';
+import LogoutModal from '../Modal/Logout';
 import { ChannelHeaderWrapper, ChannelHeaderLeft, ChannelHeaderRight } from './style';
 
 function ChannelHeader() {
   const { type, name } = useSelectedChannel();
+  const [tryLogout, setTryLogOut] = useState(false);
+
+  const logOutModalControl: ModalController = {
+    hide: () => setTryLogOut(false),
+    show: () => setTryLogOut(true),
+  };
+
   return (
-    <ChannelHeaderWrapper>
-      <ChannelHeaderLeft>
-        {name !== '' ? (
-          <>
-            <img src={`/icons/${type}Channel.png`} alt={`${type}Channel`} />
-            <p>{name}</p>
-          </>
-        ) : (
-          ''
-        )}
-      </ChannelHeaderLeft>
-      <ChannelHeaderRight>
-        <div>
-          <img src="/icons/headerNotification.png" alt="headerNotification" />
-          <img src="/icons/headerFix.png" alt="headerFix" />
-          <img src="/icons/headerUsers.png" alt="headerUsers" />
-        </div>
-        <div>
-          <p>Duxcord</p>
-        </div>
-        <div>
-          <p>LogOut</p>
-        </div>
-      </ChannelHeaderRight>
-    </ChannelHeaderWrapper>
+    <>
+      <ChannelHeaderWrapper>
+        <ChannelHeaderLeft>
+          {name !== '' ? (
+            <>
+              <img src={`/icons/${type}Channel.png`} alt={`${type}Channel`} />
+              <p>{name}</p>
+            </>
+          ) : (
+            ''
+          )}
+        </ChannelHeaderLeft>
+        <ChannelHeaderRight>
+          <div>
+            <img src="/icons/headerNotification.png" alt="headerNotification" />
+            <img src="/icons/headerFix.png" alt="headerFix" />
+            <img src="/icons/headerUsers.png" alt="headerUsers" />
+          </div>
+          <div>
+            <p>Duxcord</p>
+          </div>
+          <div>
+            <p onClick={() => setTryLogOut(!tryLogout)}>LogOut</p>
+          </div>
+        </ChannelHeaderRight>
+      </ChannelHeaderWrapper>
+      {tryLogout && <LogoutModal controller={logOutModalControl} />}
+    </>
   );
 }
 

--- a/client/src/components/Chat/UserConnection/UserConnection.tsx
+++ b/client/src/components/Chat/UserConnection/UserConnection.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import useSWR from 'swr';
 import { useGroupConnection } from '../../../hooks/useGroupConnection';
 import { useSelectedGroup } from '../../../hooks/useSelectedGroup';
+import { useUserdata } from '../../../hooks/useUserdata';
 import { getFetcher } from '../../../util/fetcher';
 import { socket } from '../../../util/socket';
 import { UserConnectionWrapper, Text, UserImage, UserTile } from './style';
@@ -9,11 +10,12 @@ import { UserConnectionWrapper, Text, UserImage, UserTile } from './style';
 function UserConnection() {
   const selectedGroup = useSelectedGroup();
   const groupConnection = useGroupConnection();
+  const { userdata } = useUserdata();
   const { data = [] } = useSWR(`/api/group/${selectedGroup?.id}/members`, getFetcher);
 
   useEffect(() => {
-    socket.emit('GroupID', selectedGroup?.code);
-  }, [selectedGroup?.code]);
+    socket.emit('GroupID', selectedGroup?.code, userdata);
+  }, [selectedGroup?.code, userdata]);
 
   return (
     <UserConnectionWrapper>

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -110,7 +110,7 @@ function Chat() {
       socket.off('thread', onThread);
     };
   }, [onChat, onLike, onThread]);
-  console.log(chats);
+
   return (
     <ChatPart>
       <ChatContainer>

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -30,7 +30,6 @@ function Chat() {
   useEffect(() => {
     if (id === null) return;
     Socket.joinChannel({ channelType: 'chatting', id });
-    console.log('join');
 
     return () => {
       Socket.leaveChannel({ channelType: 'chatting', id });
@@ -111,7 +110,7 @@ function Chat() {
       socket.off('thread', onThread);
     };
   }, [onChat, onLike, onThread]);
-
+  console.log(chats);
   return (
     <ChatPart>
       <ChatContainer>

--- a/client/src/components/Modal/Logout/index.tsx
+++ b/client/src/components/Modal/Logout/index.tsx
@@ -1,0 +1,36 @@
+import { useHistory } from 'react-router';
+import Modal from '..';
+import { ModalController } from '../../../types/modal';
+
+import Colors from '../../../styles/Colors';
+import { MiddlePart } from './style';
+import { postLogout } from '../../../api/postLogout';
+import { socket } from '../../../util/socket';
+
+function LogoutModal({ controller: { hide, show } }: { controller: ModalController }) {
+  const history = useHistory();
+  const finishModal = () => hide();
+  const logOut = async () => {
+    const isSuccess = await postLogout();
+    if (isSuccess) history.push(`/`);
+    window.location.reload();
+  };
+
+  const middleContent = <MiddlePart>정말로 로그아웃 하시겠습니까?</MiddlePart>;
+  return (
+    <Modal
+      props={{
+        title: '로그아웃',
+        middleContent,
+        bottomRightButton: {
+          text: '로그아웃',
+          color: Colors.Blue,
+          onClickHandler: logOut,
+        },
+      }}
+      controller={{ hide: finishModal, show }}
+    />
+  );
+}
+
+export default LogoutModal;

--- a/client/src/components/Modal/Logout/style.ts
+++ b/client/src/components/Modal/Logout/style.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+import Colors from '../../../styles/Colors';
+
+const MiddlePart = styled.div`
+  padding: 12px;
+  border-radius: 6px;
+  border: none;
+  background-color: ${Colors.Gray3};
+  width: 100%;
+`;
+
+export { MiddlePart };

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -20,7 +20,7 @@ function Modal({
         <div>{middleContent}</div>
         {bottomRightButton && (
           <Bottom>
-            {previous !== null ? (
+            {previous !== undefined ? (
               <div onClick={previous}>이전</div>
             ) : (
               <div onClick={hide}>닫기</div>

--- a/client/src/components/SideBar/GroupNav/index.tsx
+++ b/client/src/components/SideBar/GroupNav/index.tsx
@@ -44,7 +44,6 @@ function GroupNav() {
     history.push(`/main?group=${group.id}`);
     dispatch(setSelectedChannel({ type: '', id: null, name: '' }));
     dispatch(setSelectedGroup(group));
-    // group.id의 키에 있는 애들 다 알려줘~!
     socket.emit('GroupID', group.code);
   };
 
@@ -67,7 +66,7 @@ function GroupNav() {
       socket.off('userExit');
       socket.off('userEnter');
     };
-  }, [dispatch]);
+  }, [dispatch, selectedGroup?.code, selectedGroup?.id]);
 
   return (
     <GroupListWrapper>

--- a/client/src/pages/SignIn/index.test.tsx
+++ b/client/src/pages/SignIn/index.test.tsx
@@ -10,34 +10,34 @@ describe('SignIn은', () => {
         <SignIn />
       </MemoryRouter>,
     );
-  }
+  };
 
   context('정상적으로 그려질 때', () => {
     it('"돌아오신 것을 환영해요!"라는 문자를 보여준다.', () => {
       const { queryByText } = renderSignIn();
       expect(queryByText('돌아오신 것을 환영해요!')).toBeInTheDocument();
-    })
-  })
+    });
+  });
 
-  it('ID를 입력하면 Input이 바뀐다.',() => {
+  it('ID를 입력하면 Input이 바뀐다.', () => {
     const { container } = renderSignIn();
-    
+
     fireEvent.input(container.querySelectorAll('input')[0], {
       target: {
         value: 'Duxcord',
       },
     });
     expect(container.querySelectorAll('input')[0]).toHaveValue('Duxcord');
-  })
+  });
 
-  it('password를 입력하면 Input이 바뀐다.',() => {
+  it('password를 입력하면 Input이 바뀐다.', () => {
     const { container } = renderSignIn();
-    
+
     fireEvent.input(container.querySelectorAll('input')[1], {
       target: {
         value: '1234',
       },
     });
     expect(container.querySelectorAll('input')[1]).toHaveValue('1234');
-  })
+  });
 });

--- a/client/src/redux/groupConnection/slice.ts
+++ b/client/src/redux/groupConnection/slice.ts
@@ -7,14 +7,12 @@ const { reducer: groupConnectionReducer, actions } = createSlice({
   initialState: initState,
   reducers: {
     setGroupConnection: (state, { payload: group }) => {
-      // console.log('처음 받아오는 것', state, group);
       return [...group];
     },
     removeUserConnection: (state, { payload: connection }) => [
       ...state.filter((v: any) => v.loginID !== connection.loginID),
     ],
     addUserConnection: (state, { payload: connection }) => {
-      // console.log(connection.loginID, '이 들어와서 redux가 실행된다.');
       if (state.map((v: any) => v.loginID).includes(connection.loginID)) {
         return state;
       } else {

--- a/client/src/redux/groupConnection/slice.ts
+++ b/client/src/redux/groupConnection/slice.ts
@@ -13,7 +13,7 @@ const { reducer: groupConnectionReducer, actions } = createSlice({
       ...state.filter((v: any) => v.loginID !== connection.loginID),
     ],
     addUserConnection: (state, { payload: connection }) => {
-      if (state.map((v: any) => v.loginID).includes(connection.loginID)) {
+      if (state.some((v: any) => v.loginID === connection.loginID)) {
         return state;
       } else {
         return [...state, connection];

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -9,13 +9,14 @@ export async function socketInit(httpServer) {
 
   io = new Server(httpServer);
   io.on('connection', (socket) => {
-    socket.on('GroupID', (groupID) => {
+    socket.on('GroupID', (groupID, user) => {
+      if (user && !userConnectionInfo[groupID].map((v) => v.loginID).includes(user.loginID))
+        userConnectionInfo[groupID] = [...userConnectionInfo[groupID], user];
       socket.emit('GroupUserConnection', userConnectionInfo[groupID]);
     });
 
     socket.on('logIn', (groups, user) => {
       if (!user || !groups) return;
-
       groups?.forEach(({ code }) => {
         socket.join(`${code}`);
         io.to(`${code}`).emit('userEnter', user, code);

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -10,7 +10,7 @@ export async function socketInit(httpServer) {
   io = new Server(httpServer);
   io.on('connection', (socket) => {
     socket.on('GroupID', (groupID, user) => {
-      if (user && !userConnectionInfo[groupID].map((v) => v.loginID).includes(user.loginID))
+      if (user && !userConnectionInfo[groupID].some((v) => v.loginID === user.loginID))
         userConnectionInfo[groupID] = [...userConnectionInfo[groupID], user];
       socket.emit('GroupUserConnection', userConnectionInfo[groupID]);
     });


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#194 
#169 
#93 
## What did you do?

<!--무엇을 하셨나요?-->
- [x]  로그아웃 기능을 구현하였습니다.
- [x]  새로고침시 자신이 offline에 뜨는 버그를 수정하였습니다.


## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->

### 1. 로그 아웃 구현
로그아웃은 별도의 모달로 확인 후에 확인을 하면 로그아웃이 되도록 구현하였습니다. 모달에서 로그아웃을 누르면 백엔드로 logout요청을 보냅니다. 그 후 요청이 성공한다면 로그인 페이지로 이동한 후 현재 전역으로 관리되는 모든 state를 초기화하기위해 새로고침을 시도합니다. 따라서 API 요청 -> 새로 고침 식으로 진행됩니다.

###  2. 새로고침시 접속유저에 자신이 offline으로 뜨는 오류 수정
이 버그가 생긴 이유를 설명하겠습니다. 새로고침을 할 경우 소켓 연결을 끊고 다시 연결을 시도하는 과정이 있습니다. 이때 서버에 자신이 나간다는 것을 알리고 내가 나간것을 서버가 받아 다른 사람에게 알려줍니다.(정확하게는 자신의 속해있는 모든 그룹의 현재 접속 유저에게 뿌립니다.) 그후 자신이 다시 접속을 하면 똑같은 방식으로 자신이 속한 모든 그룹의 현재 접속인원에게 자신이 접속했다고 알립니다. 다만 자신이 offline으로 뜨는 이유는 자기 자신도 서버로 부터 접속 인원 배열을 받는데 거기에 자신이 속할때도 있고 안 속할 때도 있어서 그렇습니다. Group nav를 그리면서 1)자신이 들어왔다고 서버에 알립니다. 그리고 채팅부분을 그리면서 2)서버로부터 접속유저를 받아옵니다. 이 과정은 채팅페이지에서 새로고침을 하면 2가지 요청이 동시에 서버로 가게되고 1번과 2번의 실행순서가 보장이 되지 않아서 그렇습니다. 저는 그래서 실행순서를 보장하는 방법보다는 2번이 1번보다 먼저 실행될때는 자기 자신을 접속인원 배열에 넣어버리는 방식으로 고쳤습니다. 그 부분은 socket.ts의 다음 부분입니다.
```
 socket.on('GroupID', (groupID, user) => {
      if (user && !userConnectionInfo[groupID].map((v) => v.loginID).includes(user.loginID))
        userConnectionInfo[groupID] = [...userConnectionInfo[groupID], user];
      socket.emit('GroupUserConnection', userConnectionInfo[groupID]);
    });
```

