### PR TITLE
()=>{}을 ()=>void 타입으로 통합, 통일성 있게 prop 넘기기

### DIFF
--- a/client/src/components/Chat/AddChatReaction/index.tsx
+++ b/client/src/components/Chat/AddChatReaction/index.tsx
@@ -5,13 +5,13 @@ function AddChatReaction({
   handleLike,
   selectChat,
 }: {
-  handleLike: Function;
-  selectChat: Function;
+  handleLike: () => void;
+  selectChat: () => void;
 }) {
   return (
     <Wrapper>
-      <img src="/icons/btn-like.svg" alt="btn like" onClick={() => handleLike()} />
-      <img src="/icons/btn-thread.svg" alt="btn thread" onClick={() => selectChat()} />
+      <img src="/icons/btn-like.svg" alt="btn like" onClick={handleLike} />
+      <img src="/icons/btn-thread.svg" alt="btn thread" onClick={selectChat} />
     </Wrapper>
   );
 }

--- a/client/src/components/Chat/AddChatReaction/index.tsx
+++ b/client/src/components/Chat/AddChatReaction/index.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
-import { setSelectedChat } from '../../../redux/selectedChat/slice';
-import { ChatData } from '../../../types/chats';
 import { Wrapper } from './style';
 
-function AddChatReaction({ handleLike, chatData }: { handleLike: () => {}; chatData: ChatData }) {
-  const dispatch = useDispatch();
+function AddChatReaction({
+  handleLike,
+  selectChat,
+}: {
+  handleLike: Function;
+  selectChat: Function;
+}) {
   return (
     <Wrapper>
-      <img src="/icons/btn-like.svg" alt="btn like" onClick={handleLike} />
-      <img
-        src="/icons/btn-thread.svg"
-        alt="btn thread"
-        onClick={() => dispatch(setSelectedChat(chatData))}
-      />
+      <img src="/icons/btn-like.svg" alt="btn like" onClick={() => handleLike()} />
+      <img src="/icons/btn-thread.svg" alt="btn thread" onClick={() => selectChat()} />
     </Wrapper>
   );
 }

--- a/client/src/components/Chat/ChatInput/index.tsx
+++ b/client/src/components/Chat/ChatInput/index.tsx
@@ -3,7 +3,7 @@ import { postChat } from '../../../api/postChat';
 import { useSelectedChannel } from '../../../hooks/useSelectedChannel';
 import { ButtonWrapper, Input, Wrapper } from './style';
 
-function ChatInput({ scrollToBottom }: { scrollToBottom: Function }) {
+function ChatInput({ scrollToBottom }: { scrollToBottom: () => void }) {
   const { id } = useSelectedChannel();
   const chatInputRef = useRef<HTMLInputElement>(null);
 

--- a/client/src/components/Chat/ChatItem/index.tsx
+++ b/client/src/components/Chat/ChatItem/index.tsx
@@ -40,6 +40,8 @@ function ChatItem({ chatData }: { chatData: ChatData }) {
 
   const [isFocused, setIsFocused] = useState(false);
 
+  const selectChat = () => dispatch(setSelectedChat(chatData));
+
   return (
     <ChatWrapper onMouseEnter={() => setIsFocused(true)} onMouseLeave={() => setIsFocused(false)}>
       <UserImage src={thumbnail ?? '/images/default_profile.png'} alt="user profile" />
@@ -62,11 +64,11 @@ function ChatItem({ chatData }: { chatData: ChatData }) {
               count={threadsCount}
               lastThreadUser={threadWriter}
               threadLastTime={threadLastTime}
-              onClick={() => dispatch(setSelectedChat(chatData))}
+              selectChat={() => selectChat()}
             />
           )}
         </div>
-        {isFocused && <AddChatReaction handleLike={handleLike} chatData={chatData} />}
+        {isFocused && <AddChatReaction handleLike={handleLike} selectChat={selectChat} />}
       </div>
     </ChatWrapper>
   );

--- a/client/src/components/Chat/ChatReaction/index.tsx
+++ b/client/src/components/Chat/ChatReaction/index.tsx
@@ -7,11 +7,11 @@ function ChatReaction({
   isReactioned,
 }: {
   count: number;
-  handleLike: Function;
+  handleLike: () => void;
   isReactioned: boolean;
 }) {
   return (
-    <Wrapper onClick={() => handleLike()} isActive={isReactioned}>
+    <Wrapper onClick={handleLike} isActive={isReactioned}>
       👍 {count}
     </Wrapper>
   );

--- a/client/src/components/Chat/ChatReaction/index.tsx
+++ b/client/src/components/Chat/ChatReaction/index.tsx
@@ -7,11 +7,11 @@ function ChatReaction({
   isReactioned,
 }: {
   count: number;
-  handleLike: () => {};
+  handleLike: Function;
   isReactioned: boolean;
 }) {
   return (
-    <Wrapper onClick={handleLike} isActive={isReactioned}>
+    <Wrapper onClick={() => handleLike()} isActive={isReactioned}>
       👍 {count}
     </Wrapper>
   );

--- a/client/src/components/Chat/ThreadPreview/index.tsx
+++ b/client/src/components/Chat/ThreadPreview/index.tsx
@@ -11,10 +11,10 @@ function ThreadPreview({
   count: number;
   lastThreadUser: User;
   threadLastTime: Date;
-  selectChat: Function;
+  selectChat: () => void;
 }) {
   return (
-    <ThreadPreviewWrapper onClick={() => selectChat()}>
+    <ThreadPreviewWrapper onClick={selectChat}>
       <img src={thumbnail ? thumbnail : '/images/default_profile.png'} alt="thumbnail" />
       <p>{count}개의 댓글</p>
       <p>({new Date(threadLastTime).toLocaleTimeString('ko-KR')})</p>

--- a/client/src/components/Chat/ThreadPreview/index.tsx
+++ b/client/src/components/Chat/ThreadPreview/index.tsx
@@ -6,15 +6,15 @@ function ThreadPreview({
   count,
   lastThreadUser: { thumbnail },
   threadLastTime,
-  onClick,
+  selectChat,
 }: {
   count: number;
   lastThreadUser: User;
   threadLastTime: Date;
-  onClick: () => {};
+  selectChat: Function;
 }) {
   return (
-    <ThreadPreviewWrapper onClick={onClick}>
+    <ThreadPreviewWrapper onClick={() => selectChat()}>
       <img src={thumbnail ? thumbnail : '/images/default_profile.png'} alt="thumbnail" />
       <p>{count}개의 댓글</p>
       <p>({new Date(threadLastTime).toLocaleTimeString('ko-KR')})</p>

--- a/client/src/components/Modal/GroupAdd/index.tsx
+++ b/client/src/components/Modal/GroupAdd/index.tsx
@@ -9,13 +9,13 @@ function GroupAddModal({
   showGroupJoin,
 }: {
   controller: ModalController;
-  showGroupCreate: Function;
-  showGroupJoin: Function;
+  showGroupCreate: () => void;
+  showGroupJoin: () => void;
 }) {
   const TransporterComponent = (
     <>
-      <Transporter onClick={() => showGroupCreate()}>그룹 만들기</Transporter>
-      <Transporter onClick={() => showGroupJoin()}>그룹 참가하기</Transporter>
+      <Transporter onClick={showGroupCreate}>그룹 만들기</Transporter>
+      <Transporter onClick={showGroupJoin}>그룹 참가하기</Transporter>
     </>
   );
   return (

--- a/client/src/components/Modal/GroupAdd/index.tsx
+++ b/client/src/components/Modal/GroupAdd/index.tsx
@@ -9,13 +9,13 @@ function GroupAddModal({
   showGroupJoin,
 }: {
   controller: ModalController;
-  showGroupCreate: () => {};
-  showGroupJoin: () => {};
+  showGroupCreate: Function;
+  showGroupJoin: Function;
 }) {
   const TransporterComponent = (
     <>
-      <Transporter onClick={showGroupCreate}>그룹 만들기</Transporter>
-      <Transporter onClick={showGroupJoin}>그룹 참가하기</Transporter>
+      <Transporter onClick={() => showGroupCreate()}>그룹 만들기</Transporter>
+      <Transporter onClick={() => showGroupJoin()}>그룹 참가하기</Transporter>
     </>
   );
   return (


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#196 

## What did you do?

<!--무엇을 하셨나요?-->
* 일부 겹치는 코드조각 함수로 묶기
	쓰레드 선택 시 선택된 채팅을 디스패치하는 부분의 코드가 겹쳐 이를 함수로 묶어서 뿌려주었습니다.
* Function 타입으로 통합
	() => {}로 된 부분들을 Function으로 타입을 바꾸어주었습니다.
