### PR TITLE
chore : dev 브랜치 배포 서버 세팅 및 dev 브랜치 배포 스크립트

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,91 @@
+name: Node.js CD
+
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  deploy:
+    name: Build and Deploy to nCloud
+    runs-on: ubuntu-latest
+    env:
+      client-directory: ./client
+      server-directory: ./server
+      CI: false
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: 16.x
+
+      - name: Client npm install
+        run: npm install
+        working-directory: ${{env.client-directory}}
+
+      - name: Client Build
+        run: npm run build
+        working-directory: ${{env.client-directory}}
+
+      - name: Server npm install
+        working-directory: ${{env.server-directory}}
+        run: npm install
+
+      - name: Create .env file
+        working-directory: ${{env.server-directory}}
+        run: |
+          touch .env
+          echo DB_USER=${{ secrets.DB_USER }}\ >> .env
+          echo DB_PASSWORD=${{ secrets.DB_PASSWORD }}\ >> .env
+          echo SESSION_COOKIE_SECRET=${{ secrets.SESSION_COOKIE_SECRET }}\ >> .env
+          cat .env
+
+      - name: Server Build
+        run: npm run build
+        working-directory: ${{env.server-directory}}
+
+      - name: clean-up deploy server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT_DEV }}
+          script: |
+            rm -rf /usr/share/nginx/html/*
+            cd duxcord 
+            rm -rf *
+
+      - name: copy client file to deploy server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          source: './client/build'
+          target: '/usr/share/nginx/html'
+
+      - name: copy server file to deploy server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          source: './server/dist'
+          target: 'duxcord'
+
+      - name: start app server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          script: |
+            chown root duxcord/server
+            cd duxcord/server/dist
+            pm2 start main.js
+            pm2 restart main.js


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#212 
## What did you do?
개발 버전이 배포 환경에서 잘 동작하는지 확인하기 위한 개발용 nCloud 배포 서버 세팅(ubuntu 20.04)
dev 브랜치 자동 배포를 위한 github-action 스크립트 작성
배포서버 도메인은 duxcord-dev.kro.kr 입니다.

<!--무엇을 하셨나요?-->
- [x]  개발용 배포 서버 세팅
- [x] github-action 배포 스크립트

