### PR TITLE
Fix : 이벤트 리스너 최대 갯수 10 => 20 으로 변경

### DIFF
--- a/server/src/loaders/socket.loader.ts
+++ b/server/src/loaders/socket.loader.ts
@@ -4,14 +4,16 @@ import ConnectionEvent from '../types/socket/ConnectionEvent';
 import GroupEvent from '../types/socket/GroupEvent';
 import MeetEvent from '../types/socket/MeetEvent';
 import RoomPrefix from '../types/socket/RoomPrefix';
-
 export let io: Server;
 export const userConnectionInfo = {};
 export const meetingMembers = {};
 export const socketToMeeting = {};
 
+const MAX_LISTENERS = 20;
+
 export async function socketLoader(httpServer) {
   io = new Server(httpServer);
+  io.sockets.setMaxListeners(MAX_LISTENERS);
   io.on(ConnectionEvent.connection, (socket) => {
     socket.on(GroupEvent.groupID, (groupID, user) => {
       if (user && !userConnectionInfo[groupID].some((v) => v.loginID === user.loginID))


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#231 
## What did you do
이벤트 당 제한입니다! 로그를 확인해보니 Socket의 disconnect 이벤트에 버그로 인해 10개 이상 달리게 되어 해당 에러가 발생했던 것 같습니다.
따라서 해제할 필요가 없어보이고, dev에 머지하지 않고 close 하겠습니다~

<!--무엇을 하셨나요?-->
- [x]  이벤트 리스너 최대 갯수 제한 10 => 20 으로 변경

## 레퍼런스
<!--참고한 자료가 있나요?-->
https://github.com/angular-fullstack/generator-angular-fullstack/issues/1136
https://dololak.tistory.com/96
https://stackoverflow.com/questions/8313628/node-js-request-how-to-emitter-setmaxlisteners