### PR TITLE
chat, meetChat 컴포넌트 스크롤 UX 개선

### DIFF
--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -50,7 +50,7 @@ function Chat() {
 
   const scrollToBottom = () => {
     if (chatListRef.current === null) return;
-    chatListRef.current.scrollTop = chatListRef.current?.scrollHeight;
+    chatListRef.current.scrollTo({ top: chatListRef.current?.scrollHeight, behavior: 'smooth' });
   };
 
   useEffect(scrollToBottom, []);

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -53,7 +53,9 @@ function Chat() {
     chatListRef.current.scrollTo({ top: chatListRef.current?.scrollHeight, behavior: 'smooth' });
   };
 
-  useEffect(scrollToBottom, []);
+  useEffect(() => {
+    chatListRef.current?.scrollTo({ top: chatListRef.current?.scrollHeight });
+  }, [isEmpty]);
 
   const onChat = useCallback(
     async (chat: ChatData) => {

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -35,7 +35,10 @@ function Chat() {
   }, [id]);
 
   const onScroll = useCallback(() => {
-    if (chatListRef?.current?.scrollTop === 0 && !isReachingEnd) setSize((size) => size + 1);
+    if (chatListRef?.current?.scrollTop === 0 && !isReachingEnd) {
+      chatListRef.current.scrollTo({ top: THRESHOLD });
+      setSize((size) => size + 1);
+    }
   }, [isReachingEnd, setSize]);
 
   useEffect(() => {

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -21,7 +21,7 @@ function Chat() {
   const { id } = useSelectedChannel();
   const selectedChat = useSelectedChat();
   const { data: chats, mutate, setSize } = useSWRInfinite(API_URL.channel.getKey(id), getFetcher);
-  const isEmpty = chats?.[0]?.length === 0;
+  const isEmpty = !chats?.length;
   const isReachingEnd = isEmpty || (chats && chats[chats.length - 1]?.length < PAGE_SIZE);
   const chatListRef = useRef<HTMLDivElement>(null);
 

--- a/client/src/components/Meet/MeetChat/index.tsx
+++ b/client/src/components/Meet/MeetChat/index.tsx
@@ -48,7 +48,7 @@ function MeetChat() {
 
   const scrollToBottom = () => {
     if (!chatListRef.current) return;
-    chatListRef.current.scrollTop = chatListRef.current.scrollHeight;
+    chatListRef.current.scrollTo({ top: chatListRef.current.scrollHeight, behavior: 'smooth' });
   };
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
#187 
## What did you do?
채널 입장시 스크롤을 최하단으로 내려주는 기능이 새로고침시 작동하지 않았는데 이제는 동작합니다!
소켓에서 새 메시지를 chats[0]에 넣어주는게 아닌 chats에 넣어주는 것으로 로직이 변경되었음에도 isEmpty 로직이 수정되지 않았엇던 것을 고쳤습니다.
새 메시지 입력시 scrollTop의 값을 변경해 스크롤을 이동시키지 않고 scrollTo 메서드를 이용해 부드럽게 스크롤을 내려주도록 수정했습니다.
chat 컴포넌트에서 리버스 인피니트 스크롤 시 스크롤을 아래로 조금씩 내려줘 더 이상 불러올 항목이 없을 때 까지 스크롤을 연이어 할 수 있도록 수정해 UX를 개선했습니다.

![무한스크롤](https://user-images.githubusercontent.com/77329061/141780581-4282284b-2fc2-4c49-8d6e-3625f11f8aa2.gif)
![스크롤](https://user-images.githubusercontent.com/77329061/141780595-cdd78d5c-fd75-48fb-a181-046336af1b5d.gif)

<!--무엇을 하셨나요?-->
- [x]  isEmpty 로직 수정
- [x] scrollTo 메서드를 사용해 부드러운 스크롤 이동 구현
- [x] 리버스 인피니트 스크롤 UX 개선


## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
사용시 불편한점... 있으면... 말씀 주세욧!

