### PR TITLE
Fix : 리렌더링시 stream이 바뀌지 않아도 VideoItem이 깜빡이던 문제 수정

### DIFF
--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -250,7 +250,7 @@ function OtherVideo({ member }: { member: IMeetingUser }) {
       socket.off(MeetEvent.setToggleCam);
       clearInterval(interval);
     };
-  });
+  }, [member]);
 
   return (
     <VideoItemWrapper>

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -208,7 +208,9 @@ function OtherVideo({ member }: { member: IMeetingUser }) {
   useEffect(() => {
     if (!ref.current || !member.stream) return;
     ref.current.srcObject = member.stream;
+  }, [member.stream]);
 
+  useEffect(() => {
     socket.on(MeetEvent.setMuted, (who, muted) => {
       if (member.loginID !== who) return;
 


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->

## What did you do?
srcObject에 stream을 넣어주는 useEffect의 의존성 배열이 누락되어 리렌더링시마다 srcObject를 재할당 해주어 깜빡임이 발생했읍니다...
이제는 stream이 변경될때만 srcObject가 재할당 됩니다.

<!--무엇을 하셨나요?-->
- [x] OtherVideo의 useEffect에 의존성 배열 추가

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
useEffect를 사용할 때 의존성 배열을 꼭 꼭 꼭 신경쓰겠습니다 ㅠㅠ
