### PR TITLE
Refactor : OtherVideo 컴포넌트 분리, OtherVideo 개선

### DIFF
--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -1,0 +1,42 @@
+import { MicOffIcon } from '@components/common/Icons';
+import { useRef, useEffect } from 'react';
+import { IMeetingUser } from '..';
+import { VideoItemWrapper, VideoItem } from '../style';
+
+function OtherVideo({ member }: { member: IMeetingUser }) {
+  const ref = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (!ref.current || !member.stream) return;
+    ref.current.srcObject = member.stream;
+  }, [member.stream]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const receiver = member?.pc?.getReceivers().find((r: { track: { kind: string } }) => {
+        return r.track.kind === 'audio';
+      });
+      const source = receiver?.getSynchronizationSources()[0];
+      if (source?.audioLevel && source?.audioLevel > 0.001) {
+        ref.current?.classList.add('saying');
+      } else {
+        ref.current?.classList.remove('saying');
+      }
+    }, 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [member]);
+
+  return (
+    <VideoItemWrapper>
+      <VideoItem key={member.socketID} autoPlay playsInline ref={ref} />
+      <p>{member?.username}</p>
+      {member.mic || <MicOffIcon />}
+      {member.cam || (
+        <img src={member?.thumbnail || '/images/default_profile.png'} alt="profile"></img>
+      )}
+    </VideoItemWrapper>
+  );
+}
+export default OtherVideo;

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -38,10 +38,7 @@ const VideoItemWrapper = styled.div`
   .saying {
     border: 3px solid ${Colors.Blue};
   }
-  .mute {
-    display: block;
-  }
-  .turnOffCam {
+  img {
     display: block;
     position: absolute;
   }
@@ -60,12 +57,4 @@ const VideoItem = styled.video`
   margin-bottom: 10px;
 `;
 
-const MuteWrapper = styled.div`
-  display: none;
-`;
-
-const CamOffWrapper = styled.div`
-  display: none;
-`;
-
-export { MeetVideoWrapper, VideoItemWrapper, VideoItem, MuteWrapper, CamOffWrapper, MyImage };
+export { MeetVideoWrapper, VideoItemWrapper, VideoItem, MyImage };


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->

## What did you do?
OtherVideo 컴포넌트를 별도 파일로 분리했습니다.
기존 OtherVideo 컴포넌트는 ref와 class를 이용해 mute표시와 camOff 표시를 해줬읍니다.
그래서 리렌더링시 기존 member의 cam,mic 상태가 변경되지 않아 초기 상태로 돌아가는 문제가 있었습니다.
이를 해결하기 위해 member의 cam, mic 상태를 직접 변경해주고 그 상태를 내려받아 사용하도록 수정했습니다.
OtherVideo는 이제 Props로 넘겨 받은 member의 mic, cam으로 mute표시와 camOff 표시를 조건부 렌더링 합니다
<!--무엇을 하셨나요?-->
- [x]  OtherVideo 컴포넌트 분리
- [x] OtherVideo 컴포넌트에서 mute, camOff상태를 ref와 class를 사용해 표현하던 것을 개선

![state](https://user-images.githubusercontent.com/77329061/142141246-22f5b706-90f5-4713-80a5-80d02c798078.gif)


