### PR TITLE
[Feat/#247] 화상회의 인원 제한 기능 / 화상 인원 목록 버그 수정

### DIFF
--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import MeetEvent from '@customTypes/socket/MeetEvent';
-import { useSelectedChannel, useUserdata, useUserDevice } from '@hooks/index';
+import { useSelectedChannel, useSelectedGroup, useUserdata, useUserDevice } from '@hooks/index';
 import Socket, { socket } from '../../../utils/socket';
 import {
   MeetVideoWrapper,
@@ -38,6 +38,7 @@ function MeetVideo() {
   const { userdata } = useUserdata();
   const { id } = useSelectedChannel();
   const { mic, cam } = useUserDevice();
+  const { code } = useSelectedGroup();
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const myVideoRef = useRef<HTMLVideoElement>(null);
   const [myStream, setMyStream] = useState<MediaStream | null>(null);
@@ -155,7 +156,7 @@ function MeetVideo() {
       setMeetingMembers((members) => members.filter((member) => member.socketID !== memberID));
     });
 
-    socket.emit(MeetEvent.joinMeeting, id, { loginID, username, thumbnail, mic, cam });
+    socket.emit(MeetEvent.joinMeeting, id, code, { loginID, username, thumbnail, mic, cam });
 
     return () => {
       Socket.leaveChannel({ channelType: MeetEvent.meeting, id });

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -165,7 +165,7 @@ function MeetVideo() {
       socket.off(MeetEvent.answer);
       socket.off(MeetEvent.candidate);
       socket.off(MeetEvent.leaveMember);
-      socket.emit(MeetEvent.leaveMeeting);
+      socket.emit(MeetEvent.leaveMeeting, code);
 
       Object.values(pcs.current).forEach((pc) => pc.close());
     };

--- a/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
+++ b/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
@@ -9,18 +9,20 @@ import { ListItem } from './style';
 import { socket } from 'src/utils/socket';
 
 interface Props {
+  meetingUserCount: number;
   channelType: 'chatting' | 'meeting';
   id: number;
   name: string;
 }
 
-function ChannelListItem({ channelType, id, name }: Props) {
+function ChannelListItem({ channelType, meetingUserCount, id, name }: Props) {
   const selectedGroup = useSelectedGroup();
   const { id: selectedChannelID, type: selectedChannelType } = useSelectedChannel();
   const history = useHistory();
   const dispatch = useDispatch();
 
   const joinChannel = () => {
+    if (meetingUserCount >= 5 && channelType === 'meeting') return;
     history.push(URL.channelPage(selectedGroup?.id, channelType, id));
     dispatch(setSelectedChannel({ type: channelType, id, name }));
   };

--- a/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
+++ b/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
@@ -6,6 +6,7 @@ import { URL } from 'src/api/URL';
 import { setSelectedChannel } from '../../../../redux/selectedChannel/slice';
 import { ChannelChattingIcon, ChannelMeetingIcon, GroupDeleteIcon } from '../../../common/Icons';
 import { ListItem } from './style';
+import { socket } from 'src/utils/socket';
 
 interface Props {
   channelType: 'chatting' | 'meeting';
@@ -18,6 +19,7 @@ function ChannelListItem({ channelType, id, name }: Props) {
   const { id: selectedChannelID, type: selectedChannelType } = useSelectedChannel();
   const history = useHistory();
   const dispatch = useDispatch();
+
   const joinChannel = () => {
     history.push(URL.channelPage(selectedGroup?.id, channelType, id));
     dispatch(setSelectedChannel({ type: channelType, id, name }));

--- a/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
+++ b/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
@@ -6,7 +6,6 @@ import { URL } from 'src/api/URL';
 import { setSelectedChannel } from '../../../../redux/selectedChannel/slice';
 import { ChannelChattingIcon, ChannelMeetingIcon, GroupDeleteIcon } from '../../../common/Icons';
 import { ListItem } from './style';
-import { socket } from 'src/utils/socket';
 
 interface Props {
   meetingUserCount: number;

--- a/client/src/components/SideBar/Channels/MeetingUserList/index.tsx
+++ b/client/src/components/SideBar/Channels/MeetingUserList/index.tsx
@@ -9,7 +9,7 @@ function MeetingUserList({ meetingUser }: Props) {
   return (
     <>
       {meetingUser &&
-        meetingUser[0].map((user: any) => {
+        meetingUser.map((user: any) => {
           return (
             <MeetingUserListWrapper key={user.loginID}>
               <MeetingUserProfileWrapper>

--- a/client/src/components/SideBar/Channels/index.tsx
+++ b/client/src/components/SideBar/Channels/index.tsx
@@ -32,10 +32,12 @@ function Channels({ channelType }: Props) {
   const { groupID } = getURLParams();
 
   useEffect(() => {
+    if (channelType === 'chatting') return;
+
     const meetingchannelList = selectedGroup?.meetingChannels?.map(
       (channel: { id: number }) => channel.id,
     );
-
+    // 현재 클릭된 그룹의 미팅채널별 참여인원들을 받아온다.
     socket.emit(MeetEvent.MeetingChannelList, selectedGroup.code, meetingchannelList);
   }, [selectedGroup]);
 

--- a/client/src/components/SideBar/Channels/index.tsx
+++ b/client/src/components/SideBar/Channels/index.tsx
@@ -32,6 +32,23 @@ function Channels({ channelType }: Props) {
   const { groupID } = getURLParams();
 
   useEffect(() => {
+    socket.on(MeetEvent.MeetingUserList, (meetingUserList) => {
+      setMeetingUser({ ...meetingUserList });
+    });
+
+    socket.on('someoneIn', (targetMeetingUsers, targetMeetingID) => {
+      setMeetingUser((prevState) => ({
+        ...prevState,
+        [targetMeetingID]: targetMeetingUsers,
+      }));
+    });
+
+    return () => {
+      socket.off(MeetEvent.MeetingUserList);
+    };
+  }, []);
+
+  useEffect(() => {
     if (channelType === 'chatting') return;
 
     const meetingChannelList = selectedGroup?.meetingChannels?.map(
@@ -40,16 +57,6 @@ function Channels({ channelType }: Props) {
     // 현재 클릭된 그룹의 미팅채널별 참여인원들을 받아온다.
     socket.emit(MeetEvent.MeetingChannelList, selectedGroup.code, meetingChannelList);
   }, [selectedGroup]);
-
-  useEffect(() => {
-    socket.on(MeetEvent.MeetingUserList, (meetingUserList) => {
-      setMeetingUser({ ...meetingUserList });
-    });
-
-    return () => {
-      socket.off(MeetEvent.MeetingUserList);
-    };
-  }, []);
 
   return (
     <ChannelWrapper>

--- a/client/src/components/SideBar/Channels/index.tsx
+++ b/client/src/components/SideBar/Channels/index.tsx
@@ -36,14 +36,14 @@ function Channels({ channelType }: Props) {
       setMeetingUser({ ...meetingUserList });
     });
 
-    socket.on('someoneIn', (targetMeetingUsers, targetMeetingID) => {
+    socket.on(MeetEvent.someoneIn, (targetMeetingUsers, targetMeetingID) => {
       setMeetingUser((prevState) => ({
         ...prevState,
         [targetMeetingID]: targetMeetingUsers,
       }));
     });
 
-    socket.on('someoneOut', (targetMeetingUsers, targetMeetingID) => {
+    socket.on(MeetEvent.someoneOut, (targetMeetingUsers, targetMeetingID) => {
       setMeetingUser((prevState) => ({
         ...prevState,
         [targetMeetingID]: targetMeetingUsers,
@@ -52,6 +52,8 @@ function Channels({ channelType }: Props) {
 
     return () => {
       socket.off(MeetEvent.MeetingUserList);
+      socket.off(MeetEvent.someoneIn);
+      socket.off(MeetEvent.someoneOut);
     };
   }, []);
 
@@ -61,7 +63,7 @@ function Channels({ channelType }: Props) {
     const meetingChannelList = selectedGroup?.meetingChannels?.map(
       (channel: { id: number }) => channel.id,
     );
-    // 현재 클릭된 그룹의 미팅채널별 참여인원들을 받아온다.
+
     socket.emit(MeetEvent.MeetingChannelList, selectedGroup.code, meetingChannelList);
   }, [selectedGroup]);
 

--- a/client/src/components/SideBar/Channels/index.tsx
+++ b/client/src/components/SideBar/Channels/index.tsx
@@ -85,7 +85,12 @@ function Channels({ channelType }: Props) {
             {channels?.map((channel: any) => {
               return (
                 <div key={channel.id}>
-                  <ChannelListItem channelType={channelType} id={channel.id} name={channel.name} />
+                  <ChannelListItem
+                    meetingUserCount={meetingUser[channel.id]?.length}
+                    channelType={channelType}
+                    id={channel.id}
+                    name={channel.name}
+                  />
                   {channelType === 'meeting' && (
                     <MeetingUserList meetingUser={meetingUser[channel.id]} />
                   )}

--- a/client/src/components/SideBar/Channels/index.tsx
+++ b/client/src/components/SideBar/Channels/index.tsx
@@ -34,11 +34,11 @@ function Channels({ channelType }: Props) {
   useEffect(() => {
     if (channelType === 'chatting') return;
 
-    const meetingchannelList = selectedGroup?.meetingChannels?.map(
+    const meetingChannelList = selectedGroup?.meetingChannels?.map(
       (channel: { id: number }) => channel.id,
     );
     // 현재 클릭된 그룹의 미팅채널별 참여인원들을 받아온다.
-    socket.emit(MeetEvent.MeetingChannelList, selectedGroup.code, meetingchannelList);
+    socket.emit(MeetEvent.MeetingChannelList, selectedGroup.code, meetingChannelList);
   }, [selectedGroup]);
 
   useEffect(() => {

--- a/client/src/components/SideBar/Channels/index.tsx
+++ b/client/src/components/SideBar/Channels/index.tsx
@@ -43,6 +43,13 @@ function Channels({ channelType }: Props) {
       }));
     });
 
+    socket.on('someoneOut', (targetMeetingUsers, targetMeetingID) => {
+      setMeetingUser((prevState) => ({
+        ...prevState,
+        [targetMeetingID]: targetMeetingUsers,
+      }));
+    });
+
     return () => {
       socket.off(MeetEvent.MeetingUserList);
     };

--- a/client/src/types/socket/MeetEvent.ts
+++ b/client/src/types/socket/MeetEvent.ts
@@ -11,6 +11,8 @@ enum MeetEvent {
   MeetingChannelList = 'MeetingChannelList',
   MeetingUserList = 'MeetingUserList',
   mute = 'mute',
+  someoneIn = 'someoneIn',
+  someoneOut = 'someoneOut',
   setMuted = 'setMuted',
   toggleCam = 'toggleCam',
   setToggleCam = 'setToggleCam',

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -8,11 +8,7 @@ function SocketMeetController(socket) {
     Object.entries(meetingMembers).forEach(([channel, user]) => {
       const channelID = Number(channel);
       if (!meetingchannelList.includes(channelID)) return;
-      if (meetingUserList[channelID]) {
-        meetingUserList[channelID].push(user);
-      } else {
-        meetingUserList[channelID] = [user];
-      }
+      meetingUserList[channelID] = user;
     });
     return meetingUserList;
   };
@@ -21,7 +17,7 @@ function SocketMeetController(socket) {
     io.to(RoomPrefix.meeting + channelID).emit(MeetEvent.meetChat, chat);
   };
 
-  this.joinMeeting = (meetingID, { loginID, username, thumbnail, mic, cam }) => {
+  this.joinMeeting = (meetingID, code, { loginID, username, thumbnail, mic, cam }) => {
     socket.join(RoomPrefix.RTC + meetingID);
     socketToMeeting[socket.id] = meetingID;
     const newMember = {
@@ -44,7 +40,7 @@ function SocketMeetController(socket) {
     const membersInMeeting = meetingMembers[meetingID].filter(
       (user) => user.socketID !== socket.id,
     );
-
+    io.to(code).emit('someoneIn', meetingMembers[meetingID], meetingID);
     io.to(socket.id).emit(MeetEvent.allMeetingMembers, membersInMeeting);
   };
 

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -77,12 +77,13 @@ function SocketMeetController(socket) {
     io.to(RoomPrefix.RTC + meetingID).emit(MeetEvent.setToggleCam, who, toggleCam);
   };
 
-  this.leaveMeeting = () => {
+  this.leaveMeeting = (code) => {
     const meetingID = socketToMeeting[socket.id];
     if (meetingMembers[meetingID])
       meetingMembers[meetingID] = meetingMembers[meetingID].filter(
         (member) => member.socketID !== socket.id,
       );
+    io.to(code).emit('someoneOut', meetingMembers[meetingID], meetingID);
     io.to(RoomPrefix.RTC + meetingID).emit(MeetEvent.leaveMember, socket.id);
   };
 

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -92,7 +92,7 @@ function SocketMeetController(socket) {
 
   this.meetingChannelUserList = (code, meetingchannelList) => {
     const meetingUserList = checkMeetingUserList(meetingchannelList);
-    io.to(code).emit(MeetEvent.MeetingUserList, meetingUserList);
+    io.to(socket.id).emit(MeetEvent.MeetingUserList, meetingUserList);
   };
 }
 

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -40,7 +40,7 @@ function SocketMeetController(socket) {
     const membersInMeeting = meetingMembers[meetingID].filter(
       (user) => user.socketID !== socket.id,
     );
-    io.to(code).emit('someoneIn', meetingMembers[meetingID], meetingID);
+    io.to(code).emit(MeetEvent.someoneIn, meetingMembers[meetingID], meetingID);
     io.to(socket.id).emit(MeetEvent.allMeetingMembers, membersInMeeting);
   };
 
@@ -83,7 +83,7 @@ function SocketMeetController(socket) {
       meetingMembers[meetingID] = meetingMembers[meetingID].filter(
         (member) => member.socketID !== socket.id,
       );
-    io.to(code).emit('someoneOut', meetingMembers[meetingID], meetingID);
+    io.to(code).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
     io.to(RoomPrefix.RTC + meetingID).emit(MeetEvent.leaveMember, socket.id);
   };
 

--- a/server/src/types/socket/MeetEvent.ts
+++ b/server/src/types/socket/MeetEvent.ts
@@ -11,6 +11,8 @@ enum MeetEvent {
   MeetingChannelList = 'MeetingChannelList',
   MeetingUserList = 'MeetingUserList',
   mute = 'mute',
+  someoneIn = 'someoneIn',
+  someoneOut = 'someoneOut',
   setMuted = 'setMuted',
   toggleCam = 'toggleCam',
   setToggleCam = 'setToggleCam',


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #247 

## What did you do?
고민의 흔적..
![KakaoTalk_Photo_2021-11-17-18-58-53](https://user-images.githubusercontent.com/52554235/142179067-c5819320-8097-4365-9522-2576ccecb3f9.jpeg)


<!--무엇을 하셨나요?-->
- [x] 화상인원 목록 버그 수정(단 브라우저를 닫을 경우를 손봐야함)
- [x] 화상인원에 5명만 들어올 수 있도록 구현

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
브라우저를 닫을 경우도 손보겠습니다!
직관적으로 짜려고 했습니다. 그룹을 누르면 현재 화상채널에 참여현황을 받아오고 자신이 화상채널에 들어가면 그룹인원들에게 알립니다. 그 후 다시 떠나면 자신이 떠났다고 알립니다. 브라우저를 닫을 경우는 disconnect부분을 손봐야할 것 같습니다!
