### PR TITLE
[Fix/#191] 화상회의 채널에서 브라우저를 닫아 퇴장하는 경우 회의 멤버 목록에서 제거되지 않는 버그 제거

### DIFF
--- a/server/src/controllers/socket/group.socket.ts
+++ b/server/src/controllers/socket/group.socket.ts
@@ -6,7 +6,10 @@ function SocketGroupController(socket) {
   this.groupID = (groupID, user) => {
     if (!userConnectionInfo[groupID]) return;
     if (user && !userConnectionInfo[groupID]?.some((v) => v.loginID === user.loginID))
-      userConnectionInfo[groupID] = [...userConnectionInfo[groupID], user];
+      userConnectionInfo[groupID] = [
+        ...userConnectionInfo[groupID],
+        { ...user, socketID: socket.id },
+      ];
     socket.emit(GroupEvent.groupUserConnection, userConnectionInfo[groupID]);
   };
 
@@ -17,10 +20,10 @@ function SocketGroupController(socket) {
       io.to(`${code}`).emit(GroupEvent.userEnter, user, code);
       if (userConnectionInfo[code]) {
         if (!userConnectionInfo[code].map((v) => v.loginID).includes(user.loginID)) {
-          userConnectionInfo[code].push(user);
+          userConnectionInfo[code].push({ ...user, socketID: socket.id });
         }
       } else {
-        userConnectionInfo[code] = [user];
+        userConnectionInfo[code] = [{ ...user, socketID: socket.id }];
       }
     });
 

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -1,4 +1,9 @@
-import { io, meetingMembers, socketToMeeting } from '../../loaders/socket.loader';
+import {
+  io,
+  meetingMembers,
+  socketToMeeting,
+  userConnectionInfo,
+} from '../../loaders/socket.loader';
 import MeetEvent from '../../types/socket/MeetEvent';
 import RoomPrefix from '../../types/socket/RoomPrefix';
 
@@ -7,7 +12,7 @@ function SocketMeetController(socket) {
     const meetingUserList = {};
     Object.entries(meetingMembers).forEach(([channel, user]) => {
       const channelID = Number(channel);
-      if (!meetingchannelList.includes(channelID)) return;
+      if (!meetingchannelList?.includes(channelID)) return;
       meetingUserList[channelID] = user;
     });
     return meetingUserList;
@@ -83,7 +88,15 @@ function SocketMeetController(socket) {
       meetingMembers[meetingID] = meetingMembers[meetingID].filter(
         (member) => member.socketID !== socket.id,
       );
-    io.to(code).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
+
+    if (code === 'transport close') {
+      const code = Object.keys(userConnectionInfo).find((key) =>
+        userConnectionInfo[key].some((v) => v.socketID === socket.id),
+      );
+      io.to(code).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
+    } else {
+      io.to(code).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
+    }
     io.to(RoomPrefix.RTC + meetingID).emit(MeetEvent.leaveMember, socket.id);
   };
 

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -4,6 +4,7 @@ import {
   socketToMeeting,
   userConnectionInfo,
 } from '../../loaders/socket.loader';
+import ConnectionEvent from '../../types/socket/ConnectionEvent';
 import MeetEvent from '../../types/socket/MeetEvent';
 import RoomPrefix from '../../types/socket/RoomPrefix';
 
@@ -82,20 +83,20 @@ function SocketMeetController(socket) {
     io.to(RoomPrefix.RTC + meetingID).emit(MeetEvent.setToggleCam, who, toggleCam);
   };
 
-  this.leaveMeeting = (code) => {
+  this.leaveMeeting = (groupCode) => {
     const meetingID = socketToMeeting[socket.id];
     if (meetingMembers[meetingID])
       meetingMembers[meetingID] = meetingMembers[meetingID].filter(
         (member) => member.socketID !== socket.id,
       );
 
-    if (code === 'transport close') {
-      const code = Object.keys(userConnectionInfo).find((key) =>
+    if (groupCode === ConnectionEvent.close) {
+      const groupCode = Object.keys(userConnectionInfo).find((key) =>
         userConnectionInfo[key].some((v) => v.socketID === socket.id),
       );
-      io.to(code).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
+      io.to(groupCode).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
     } else {
-      io.to(code).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
+      io.to(groupCode).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
     }
     io.to(RoomPrefix.RTC + meetingID).emit(MeetEvent.leaveMember, socket.id);
   };

--- a/server/src/types/socket/ConnectionEvent.ts
+++ b/server/src/types/socket/ConnectionEvent.ts
@@ -1,6 +1,7 @@
 enum ConnectionEvent {
   connection = 'connection',
   disconnect = 'disconnect',
+  close = 'transport close',
 }
 
 export default ConnectionEvent;


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #191
## What did you do?

<!--무엇을 하셨나요?-->
- [x]  화상회의 채널에서 브라우저를 닫아 퇴장하는 경우 회의 멤버 목록에서 제거되지 않는 버그 제거


## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
현재 창을 끄거나 로그아웃을 하면 disconnect가 일어나는데 지금 로직에서는 disconnect하는 주최가 퇴장당시의 그룹 코드를 모르기 때문에 발생한 것입니다. 그래서 socket.id를 이용해 선형탐색으로 이 사람이 속한 그룹의 코드를 찾아 냅니다. 그 후 에밋을 하는 방식으로 구현했습니다.

