### PR TITLE
[Fix/#246] 유저 목록 갱신 시 복수개의 윈도우를 띄운 유저가 한 윈도우를 닫으면 Offline으로 보이는 오류 수정

### DIFF
--- a/server/src/controllers/socket/group.socket.ts
+++ b/server/src/controllers/socket/group.socket.ts
@@ -26,7 +26,7 @@ function SocketGroupController(socket) {
         userConnectionInfo[code] = [{ ...user, socketID: socket.id }];
       }
     });
-
+    console.log(userConnectionInfo);
     const userDisconnect = () => {
       Object.keys(userConnectionInfo).forEach((v) => {
         userConnectionInfo[v] = userConnectionInfo[v].filter((a) => a.loginID !== user.loginID);

--- a/server/src/controllers/socket/group.socket.ts
+++ b/server/src/controllers/socket/group.socket.ts
@@ -19,20 +19,34 @@ function SocketGroupController(socket) {
       socket.join(`${code}`);
       io.to(`${code}`).emit(GroupEvent.userEnter, user, code);
       if (userConnectionInfo[code]) {
-        if (!userConnectionInfo[code].map((v) => v.loginID).includes(user.loginID)) {
-          userConnectionInfo[code].push({ ...user, socketID: socket.id });
+        const currentUserIndex = userConnectionInfo[code].findIndex(
+          (v) => v.loginID === user.loginID,
+        );
+        if (currentUserIndex === -1) {
+          userConnectionInfo[code].push({ ...user, socketID: [socket.id] });
+        } else {
+          userConnectionInfo[code][currentUserIndex].socketID.push(socket.id);
         }
       } else {
-        userConnectionInfo[code] = [{ ...user, socketID: socket.id }];
+        userConnectionInfo[code] = [{ ...user, socketID: [socket.id] }];
       }
     });
-    console.log(userConnectionInfo);
+
     const userDisconnect = () => {
       Object.keys(userConnectionInfo).forEach((v) => {
-        userConnectionInfo[v] = userConnectionInfo[v].filter((a) => a.loginID !== user.loginID);
-      });
-      groups?.forEach(({ code }) => {
-        io.to(`${code}`).emit(GroupEvent.userExit, user, code);
+        let isCompleteDisconnect = false;
+        userConnectionInfo[v].forEach((oneUser) => {
+          if (oneUser.loginID === user.loginID) {
+            oneUser.socketID = oneUser.socketID.filter((socketID) => socketID !== socket.id);
+          }
+          if (oneUser.socketID.length === 0) isCompleteDisconnect = true;
+        });
+        if (isCompleteDisconnect) {
+          userConnectionInfo[v] = userConnectionInfo[v].filter((a) => a.loginID !== user.loginID);
+          groups?.forEach(({ code }) => {
+            io.to(`${code}`).emit(GroupEvent.userExit, user, code);
+          });
+        }
       });
     };
 

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -92,7 +92,7 @@ function SocketMeetController(socket) {
 
     if (groupCode === ConnectionEvent.close) {
       const groupCodes = Object.keys(userConnectionInfo).filter((key) =>
-        userConnectionInfo[key].some((v) => v.socketID === socket.id),
+        userConnectionInfo[key].some((v) => v.socketID.includes(socket.id)),
       );
       groupCodes.forEach((groupCode) => {
         io.to(groupCode).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -91,10 +91,12 @@ function SocketMeetController(socket) {
       );
 
     if (groupCode === ConnectionEvent.close) {
-      const groupCode = Object.keys(userConnectionInfo).find((key) =>
+      const groupCodes = Object.keys(userConnectionInfo).filter((key) =>
         userConnectionInfo[key].some((v) => v.socketID === socket.id),
       );
-      io.to(groupCode).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
+      groupCodes.forEach((groupCode) => {
+        io.to(groupCode).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
+      });
     } else {
       io.to(groupCode).emit(MeetEvent.someoneOut, meetingMembers[meetingID], meetingID);
     }


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #246 
## What did you do?
유저 목록 갱신 시 복수개의 윈도우를 띄운 유저가 한 윈도우를 닫으면 Offline으로 보이는 오류 수정

<!--무엇을 하셨나요?-->
- [x]  유저 목록 갱신 시 복수개의 윈도우를 띄운 유저가 한 윈도우를 닫으면 Offline으로 보이는 오류 수정
- [x]  유저관리 형식 변경에 의한 화상채널 퇴장 로직 수정

## 팀원들에게 할 말
일단 버그를 만들어서 죄송합니다 ㅠㅠㅠ 
서진님이 알려주신 버그의 원인은 하나의 유저가 여러개의 브라우저로 접속을 해도 백엔드에서 현재 접속인원을 파악하는 로직이 loginID로 구성되어 있었기에 그런 현상이 일어났습니다.  

밑의 객체는 수정을 하기 전 서버에서 그룹별 현재 접속 유저를 관리하는 객체입니다. 
밑의 예시는 로그인 아이디가 `tlsgyrms12`인 유저가 접속을 함으로서 서버에서 변경된 결과라고 볼 수 있습니다.
```
{
 // 그룹 코드
  OTk0MDMx: [
   // 현재 그 그룹에 접속해 있는 user들의 정보
    {
      loginID: 'tlsgyrms12',
      username: '근12',
      thumbnail: null,
      bio: null,
      socketID: 'AU_Azzz_AISN2321'
    }
  ],
  ODgxNDg5: [
    {
      loginID: 'tlsgyrms12',
      username: '근12',
      thumbnail: null,
      bio: null,
      socketID: 'AU_Azzz_AISN2321'
    }
  ]
}
```
하지만 이렇게 작성할 경우 똑같은 로그인 아이디여도 소켓아이디가 다른 사용자를 관리 할 수 없습니다. 따라서 여러개의 브라우저로 같은 로그인으로 접속을 해도 위의 객체는 변함이 없습니다. 하지만 하나라도 퇴장을 하면 위의 객체에서 나갔다고 인지해서 위의 객체를 바꿔버리게 되어서 버그가 발생했습니다.

따라서 밑의 형식으로 수정을 했습니다.
```
{
 // 그룹 코드
  OTk0MDMx: [
   // 현재 그 그룹에 접속해 있는 user들의 정보
    {
      loginID: 'tlsgyrms12',
      username: '근12',
      thumbnail: null,
      bio: null,
      socketID: ['AU_Azzz_AISN2321' , 'ZOS_aks_123asdkc']
    }
  ],
  ODgxNDg5: [
    {
      loginID: 'tlsgyrms12',
      username: '근12',
      thumbnail: null,
      bio: null,
      socketID: ['AU_Azzz_AISN2321' , 'ZOS_aks_123asdkc']
    }
  ]
}
```
바뀐 것은 현재 접속한 사람에게 여러개의 소켓아이디가 있을 수 있음을 인지하여 배열로 관리를 하도록 바꿔서 진짜 사용자가 퇴장하는 조건은 연결된 소켓아이디가 하나도 없을 때로 인지하도록 로직을 수정하였습니다! 🤔