### PR TITLE
Feat/화면 공유 기능

### DIFF
--- a/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
+++ b/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { MeetingStopIcon, ScreenShareStartIcon } from '../../common/Icons';
+import { MeetingStopIcon, ScreenShareStartIcon } from '../../../common/Icons';
 import { MeetButtonWrapper } from './style';
 
-function MeetButton() {
+function MeetButton({ onClick }: { onClick: () => void }) {
   return (
     <MeetButtonWrapper>
-      <button>
+      <button onClick={onClick}>
         <ScreenShareStartIcon stroke="white" />
       </button>
       <button>

--- a/client/src/components/Meet/MeetVideo/MeetButton/style.ts
+++ b/client/src/components/Meet/MeetVideo/MeetButton/style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Colors from '../../../../styles/Colors';
+import Colors from '@styles/Colors';
 
 const MeetButtonWrapper = styled.div`
   width: 100%;

--- a/client/src/components/Meet/MeetVideo/MeetButton/style.ts
+++ b/client/src/components/Meet/MeetVideo/MeetButton/style.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Colors from '../../../styles/Colors';
+import Colors from '../../../../styles/Colors';
 
 const MeetButtonWrapper = styled.div`
   width: 100%;

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -3,23 +3,27 @@ import { useRef, useEffect } from 'react';
 import { IMeetingUser } from '..';
 import { VideoItemWrapper, VideoItem } from '../style';
 
-function OtherVideo({ member }: { member: IMeetingUser }) {
+function OtherVideo({
+  member: { socketID, loginID, username, thumbnail, cam, speaker, mic, stream, screen, pc },
+}: {
+  member: IMeetingUser;
+}) {
   const camRef = useRef<HTMLVideoElement>(null);
   const screenRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
-    if (!camRef.current || !member.stream) return;
-    camRef.current.srcObject = member.stream;
-  }, [member.stream]);
+    if (!camRef.current || !stream) return;
+    camRef.current.srcObject = stream;
+  }, [stream]);
 
   useEffect(() => {
-    if (!screenRef.current || !member.screen) return;
-    screenRef.current.srcObject = member.screen;
-  }, [member.screen]);
+    if (!screenRef.current || !screen) return;
+    screenRef.current.srcObject = screen;
+  }, [screen]);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const receiver = member?.pc?.getReceivers().find((r: { track: { kind: string } }) => {
+      const receiver = pc?.getReceivers().find((r: { track: { kind: string } }) => {
         return r.track.kind === 'audio';
       });
       const source = receiver?.getSynchronizationSources()[0];
@@ -32,29 +36,21 @@ function OtherVideo({ member }: { member: IMeetingUser }) {
     return () => {
       clearInterval(interval);
     };
-  }, [member]);
+  }, [pc]);
 
   return (
     <>
       <VideoItemWrapper>
-        <VideoItem
-          key={member.socketID}
-          muted={!member.speaker}
-          autoPlay
-          playsInline
-          ref={camRef}
-        />
-        <p>{member?.username}</p>
-        {member.mic || <MicOffIcon />}
-        {member.speaker || <SpeakerOffIcon />}
-        {member.cam || (
-          <img src={member?.thumbnail || '/images/default_profile.png'} alt="profile"></img>
-        )}
+        <VideoItem muted={!speaker} autoPlay playsInline ref={camRef} />
+        <p>{`${username}(${loginID})`}</p>
+        {mic || <MicOffIcon />}
+        {speaker || <SpeakerOffIcon />}
+        {cam || <img src={thumbnail || '/images/default_profile.png'} alt="profile"></img>}
       </VideoItemWrapper>
-      {member.screen && (
+      {screen && (
         <VideoItemWrapper>
-          <VideoItem key={member.socketID} autoPlay playsInline ref={screenRef} />
-          <p>{member?.username + '님의 화면'}</p>
+          <VideoItem key={socketID} autoPlay playsInline ref={screenRef} />
+          <p>{`${username}(${loginID})님의 화면`}</p>
         </VideoItemWrapper>
       )}
     </>

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -4,11 +4,11 @@ import { IMeetingUser } from '..';
 import { VideoItemWrapper, VideoItem } from '../style';
 
 function OtherVideo({ member }: { member: IMeetingUser }) {
-  const ref = useRef<HTMLVideoElement>(null);
+  const camRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
-    if (!ref.current || !member.stream) return;
-    ref.current.srcObject = member.stream;
+    if (!camRef.current || !member.stream) return;
+    camRef.current.srcObject = member.stream;
   }, [member.stream]);
 
   useEffect(() => {
@@ -18,9 +18,9 @@ function OtherVideo({ member }: { member: IMeetingUser }) {
       });
       const source = receiver?.getSynchronizationSources()[0];
       if (source?.audioLevel && source?.audioLevel > 0.001) {
-        ref.current?.classList.add('saying');
+        camRef.current?.classList.add('saying');
       } else {
-        ref.current?.classList.remove('saying');
+        camRef.current?.classList.remove('saying');
       }
     }, 1000);
     return () => {
@@ -30,7 +30,7 @@ function OtherVideo({ member }: { member: IMeetingUser }) {
 
   return (
     <VideoItemWrapper>
-      <VideoItem key={member.socketID} autoPlay playsInline ref={ref} />
+        <VideoItem key={member.socketID} autoPlay playsInline ref={camRef} />
       <p>{member?.username}</p>
       {member.mic || <MicOffIcon />}
       {member.cam || (

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -5,11 +5,17 @@ import { VideoItemWrapper, VideoItem } from '../style';
 
 function OtherVideo({ member }: { member: IMeetingUser }) {
   const camRef = useRef<HTMLVideoElement>(null);
+  const screenRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
     if (!camRef.current || !member.stream) return;
     camRef.current.srcObject = member.stream;
   }, [member.stream]);
+
+  useEffect(() => {
+    if (!screenRef.current || !member.screen) return;
+    screenRef.current.srcObject = member.screen;
+  }, [member.screen]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -29,14 +35,22 @@ function OtherVideo({ member }: { member: IMeetingUser }) {
   }, [member]);
 
   return (
-    <VideoItemWrapper>
+    <>
+      <VideoItemWrapper>
         <VideoItem key={member.socketID} autoPlay playsInline ref={camRef} />
-      <p>{member?.username}</p>
-      {member.mic || <MicOffIcon />}
-      {member.cam || (
-        <img src={member?.thumbnail || '/images/default_profile.png'} alt="profile"></img>
+        <p>{member?.username}</p>
+        {member.mic || <MicOffIcon />}
+        {member.cam || (
+          <img src={member?.thumbnail || '/images/default_profile.png'} alt="profile"></img>
+        )}
+      </VideoItemWrapper>
+      {member.screen && (
+        <VideoItemWrapper>
+          <VideoItem key={member.socketID} autoPlay playsInline ref={screenRef} />
+          <p>{member?.username + '님의 화면'}</p>
+        </VideoItemWrapper>
       )}
-    </VideoItemWrapper>
+    </>
   );
 }
 export default OtherVideo;

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -242,6 +242,8 @@ function MeetVideo() {
       socket.emit(MeetEvent.leaveMeeting);
 
       Object.values(pcs.current).forEach((pc) => pc.close());
+      myStreamRef.current?.getTracks().forEach((track) => track.stop());
+      myScreenStreamRef.current?.getTracks().forEach((track) => track.stop());
     };
   }, [id]);
 

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -44,6 +44,18 @@ function MeetVideo() {
   const pcs = useRef<{ [socketID: string]: RTCPeerConnection }>({});
   const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
 
+  const applyDeviceStatus = useCallback(
+    ({ stream, video, audio }: { stream: MediaStream; video: boolean; audio: boolean }) => {
+      stream?.getVideoTracks().forEach((track) => {
+        track.enabled = video;
+      });
+      stream?.getAudioTracks().forEach((track) => {
+        track.enabled = audio;
+      });
+    },
+    [],
+  );
+
   const getMyStream = async () => {
     let myStream;
     try {
@@ -59,6 +71,7 @@ function MeetVideo() {
       myVideoRef.current.srcObject = myStream;
       highlightMyVolume(myStream, myVideoRef.current);
     }
+    applyDeviceStatus({ stream: myStream, video: cam, audio: mic });
     myStreamRef.current = myStream;
   };
 
@@ -248,12 +261,8 @@ function MeetVideo() {
   }, [id]);
 
   useEffect(() => {
-    myStreamRef.current?.getAudioTracks().forEach((track) => {
-      track.enabled = mic;
-    });
-    myStreamRef.current?.getVideoTracks().forEach((track) => {
-      track.enabled = cam;
-    });
+    if (myStreamRef.current)
+      applyDeviceStatus({ stream: myStreamRef.current, video: cam, audio: mic });
   }, [mic, cam]);
 
   useEffect(() => {

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -324,14 +324,14 @@ function MeetVideo() {
           ) : (
             <MyImage src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
           )}
-          <p>{userdata?.username}</p>
+          <p>{`${userdata?.username}(${userdata?.loginID})`}</p>
           {mic ? '' : <MicOffIcon />}
           {speaker ? '' : <SpeakerOffIcon />}
         </VideoItemWrapper>
         {screenShare && (
           <VideoItemWrapper>
             <VideoItem autoPlay playsInline muted ref={myScreenRef} />
-            <p>{userdata?.username + '님의 화면'}</p>
+            <p>{`${userdata?.username}(${userdata?.loginID})님의 화면`}</p>
           </VideoItemWrapper>
         )}
         {meetingMembers.map((member) => (

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -6,6 +6,7 @@ import { MeetVideoWrapper, VideoItemWrapper, VideoItem, MyImage } from './style'
 import { highlightMyVolume } from '../../../utils/audio';
 import { MicOffIcon } from '@components/common/Icons';
 import OtherVideo from './OtherVideo';
+import MeetButton from './MeetButton';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
 
@@ -25,6 +26,7 @@ export interface IMeetingUser {
   mic: boolean;
   cam: boolean;
   stream?: MediaStream;
+  screen?: MediaStream;
   pc?: RTCPeerConnection;
 }
 
@@ -34,7 +36,10 @@ function MeetVideo() {
   const { mic, cam } = useUserDevice();
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const myVideoRef = useRef<HTMLVideoElement>(null);
-  const [myStream, setMyStream] = useState<MediaStream | null>(null);
+  const myStreamRef = useRef<MediaStream | null>(null);
+  const myScreenRef = useRef<HTMLVideoElement>(null);
+  const myScreenStreamRef = useRef<MediaStream | null>(null);
+  const [screenShare, setScreenShare] = useState(false);
   const [meetingMembers, setMeetingMembers] = useState<IMeetingUser[]>([]);
   const pcs = useRef<{ [socketID: string]: RTCPeerConnection }>({});
   const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
@@ -54,46 +59,109 @@ function MeetVideo() {
       myVideoRef.current.srcObject = myStream;
       highlightMyVolume(myStream, myVideoRef.current);
     }
-    setMyStream(myStream);
+    myStreamRef.current = myStream;
   };
 
-  const createPeerConnection = useCallback(
-    (member: IMeetingUser) => {
-      const pc = new RTCPeerConnection(pcConfig);
+  const createPeerConnection = useCallback((member: IMeetingUser) => {
+    if (pcs.current[member.socketID]) return pcs.current[member.socketID];
+    const pc = new RTCPeerConnection(pcConfig);
 
-      pc.onicecandidate = (data) => {
-        if (!data.candidate) return;
+    pc.onicecandidate = (data) => {
+      if (!data.candidate) return;
 
-        socket.emit(MeetEvent.candidate, {
-          candidate: data.candidate,
+      socket.emit(MeetEvent.candidate, {
+        candidate: data.candidate,
+        receiverID: member.socketID,
+      });
+    };
+
+    pc.onnegotiationneeded = async () => {
+      try {
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(new RTCSessionDescription(offer));
+        socket.emit(MeetEvent.offer, {
+          offer,
           receiverID: member.socketID,
+          member: {},
         });
-      };
-
-      pc.ontrack = (data) => {
-        setMeetingMembers((members): IMeetingUser[] => [
-          ...members.filter((m: IMeetingUser) => m.socketID !== member.socketID),
-          {
-            ...member,
-            stream: data.streams[0],
-            pc,
-          },
-        ]);
-      };
-
-      if (myStream) {
-        myStream.getTracks().forEach((track) => {
-          if (myStream) pc.addTrack(track, myStream);
-        });
+      } catch (e) {
+        console.error(e);
       }
-      return pc;
-    },
-    [myStream],
-  );
+    };
+
+    pc.ontrack = (e) => {
+      setMeetingMembers((members): IMeetingUser[] => {
+        let mem = members.find((m) => m.socketID === member.socketID);
+        if (!mem) {
+          mem = { ...member, pc };
+          members.push(mem);
+        }
+
+        const newStream = e.streams[0];
+
+        if (mem.stream && mem.stream.id !== e.streams[0].id) {
+          newStream.onremovetrack = () => {
+            setMeetingMembers((members) => {
+              const m = members.find((m) => m.socketID === member.socketID);
+              if (!m) return members;
+              delete m.screen;
+              return [...members];
+            });
+          };
+          mem.screen = newStream;
+        } else {
+          mem.stream = newStream;
+        }
+
+        return [...members];
+      });
+    };
+
+    myStreamRef.current?.getTracks().forEach((track) => {
+      if (myStreamRef.current) pc.addTrack(track, myStreamRef.current);
+    });
+
+    myScreenStreamRef.current?.getTracks().forEach((track) => {
+      if (myScreenStreamRef.current) pc.addTrack(track, myScreenStreamRef.current);
+    });
+
+    return pc;
+  }, []);
+
+  const getMyScreen = async () => {
+    try {
+      const myScreen = await navigator.mediaDevices.getDisplayMedia({
+        audio: true,
+        video: true,
+      });
+
+      if (myScreenRef.current) myScreenRef.current.srcObject = myScreen;
+
+      myScreen.getTracks().forEach((track) => {
+        track.onended = () => setScreenShare(false);
+        Object.values(pcs.current).forEach((pc) => pc.addTrack(track, myScreen));
+      });
+
+      myScreenStreamRef.current = myScreen;
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   useEffect(() => {
-    getMyStream();
-  }, []);
+    if (screenShare) getMyScreen();
+    else {
+      Object.values(pcs.current).forEach((pc) => {
+        const senders = pc.getSenders();
+        const tracks = myScreenStreamRef.current?.getTracks();
+        const screenSenders = senders.filter((sender) =>
+          tracks?.some((track) => track.id === sender.track?.id),
+        );
+        screenSenders.forEach((sender) => pc.removeTrack(sender));
+      });
+      myScreenStreamRef.current = null;
+    }
+  }, [screenShare]);
 
   useEffect(() => {
     if (id === null || userdata === undefined) return;
@@ -101,9 +169,10 @@ function MeetVideo() {
 
     Socket.joinChannel({ channelType: MeetEvent.meeting, id });
     socket.on(MeetEvent.allMeetingMembers, async (members) => {
+      await getMyStream();
       members.forEach(async (member: IMeetingUser) => {
         try {
-          const pc = await createPeerConnection(member);
+          const pc = createPeerConnection(member);
           if (!pc) return;
           pcs.current = { ...pcs.current, [member.socketID]: pc };
           const offer = await pc.createOffer();
@@ -121,25 +190,37 @@ function MeetVideo() {
     });
 
     socket.on(MeetEvent.offer, async ({ offer, member }) => {
-      const pc = createPeerConnection(member);
-      if (!pc) return;
-      pcs.current[member.socketID] = pc;
-      pc.setRemoteDescription(new RTCSessionDescription(offer));
-      const answer = await pc.createAnswer();
-      pc.setLocalDescription(new RTCSessionDescription(answer));
-      socket.emit(MeetEvent.answer, { answer, receiverID: member.socketID });
+      try {
+        const pc = createPeerConnection(member);
+        if (!pc) return;
+        pcs.current[member.socketID] = pc;
+        pc.setRemoteDescription(new RTCSessionDescription(offer));
+        const answer = await pc.createAnswer();
+        pc.setLocalDescription(new RTCSessionDescription(answer));
+        socket.emit(MeetEvent.answer, { answer, receiverID: member.socketID });
+      } catch (e) {
+        console.error(e);
+      }
     });
 
-    socket.on(MeetEvent.answer, ({ answer, senderID }) => {
-      const pc = pcs.current[senderID];
-      if (!pc) return;
-      pc.setRemoteDescription(new RTCSessionDescription(answer));
+    socket.on(MeetEvent.answer, async ({ answer, senderID }) => {
+      try {
+        const pc = pcs.current[senderID];
+        if (!pc) return;
+        await pc.setRemoteDescription(new RTCSessionDescription(answer));
+      } catch (e) {
+        console.error(e);
+      }
     });
 
     socket.on(MeetEvent.candidate, async ({ candidate, senderID }) => {
-      const pc = pcs.current[senderID];
-      if (!pc) return;
-      await pc.addIceCandidate(new RTCIceCandidate(candidate));
+      try {
+        const pc = pcs.current[senderID];
+        if (!pc) return;
+        await pc.addIceCandidate(new RTCIceCandidate(candidate));
+      } catch (e) {
+        console.error(e);
+      }
     });
 
     socket.on(MeetEvent.leaveMember, (memberID) => {
@@ -162,18 +243,16 @@ function MeetVideo() {
 
       Object.values(pcs.current).forEach((pc) => pc.close());
     };
-  }, [id, userdata, createPeerConnection]);
+  }, [id]);
 
   useEffect(() => {
-    if (myStream) {
-      myStream.getAudioTracks().forEach((track) => {
-        track.enabled = mic;
-      });
-      myStream.getVideoTracks().forEach((track) => {
-        track.enabled = cam;
-      });
-    }
-  }, [mic, cam, myStream]);
+    myStreamRef.current?.getAudioTracks().forEach((track) => {
+      track.enabled = mic;
+    });
+    myStreamRef.current?.getVideoTracks().forEach((track) => {
+      track.enabled = cam;
+    });
+  }, [mic, cam]);
 
   useEffect(() => {
     socket.on(MeetEvent.setMuted, (who, micStatus) => {
@@ -201,21 +280,40 @@ function MeetVideo() {
   }, []);
 
   return (
-    <MeetVideoWrapper ref={videoWrapperRef} videoCount={videoCount || 0}>
-      <VideoItemWrapper>
-        <VideoItem autoPlay playsInline muted ref={myVideoRef} />
-        {cam ? (
-          ''
-        ) : (
-          <MyImage src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
+    <>
+      <MeetVideoWrapper ref={videoWrapperRef} videoCount={videoCount || 0}>
+        <VideoItemWrapper>
+          <VideoItem autoPlay playsInline muted ref={myVideoRef} />
+          {cam ? (
+            ''
+          ) : (
+            <MyImage src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
+          )}
+          <p>{userdata?.username}</p>
+          {mic ? '' : <MicOffIcon />}
+        </VideoItemWrapper>
+        {screenShare && (
+          <VideoItemWrapper>
+            <VideoItem autoPlay playsInline muted ref={myScreenRef} />
+            <p>{userdata?.username + '님의 화면'}</p>
+          </VideoItemWrapper>
         )}
-        <p>{userdata?.username}</p>
-        {mic ? '' : <MicOffIcon />}
-      </VideoItemWrapper>
-      {meetingMembers.map((member) => (
-        <OtherVideo key={member.socketID} member={member} />
-      ))}
-    </MeetVideoWrapper>
+        {meetingMembers.map((member) => (
+          <OtherVideo key={member.socketID} member={member} />
+        ))}
+      </MeetVideoWrapper>
+      <MeetButton
+        onClick={() => {
+          if (screenShare) {
+            const tracks = myScreenStreamRef.current?.getTracks();
+            tracks?.forEach((track) => track.stop());
+            setScreenShare(false);
+          } else {
+            setScreenShare(true);
+          }
+        }}
+      />
+    </>
   );
 }
 

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -18,6 +18,23 @@ const pcConfig = {
   ],
 };
 
+const applyDeviceStatus = ({
+  stream,
+  video,
+  audio,
+}: {
+  stream: MediaStream;
+  video: boolean;
+  audio: boolean;
+}) => {
+  stream?.getVideoTracks().forEach((track) => {
+    track.enabled = video;
+  });
+  stream?.getAudioTracks().forEach((track) => {
+    track.enabled = audio;
+  });
+};
+
 export interface IMeetingUser {
   socketID: string;
   loginID: string;
@@ -36,25 +53,13 @@ function MeetVideo() {
   const { mic, cam } = useUserDevice();
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const myVideoRef = useRef<HTMLVideoElement>(null);
-  const myStreamRef = useRef<MediaStream | null>(null);
+  const myStreamRef = useRef<MediaStream>();
   const myScreenRef = useRef<HTMLVideoElement>(null);
-  const myScreenStreamRef = useRef<MediaStream | null>(null);
+  const myScreenStreamRef = useRef<MediaStream>();
   const [screenShare, setScreenShare] = useState(false);
   const [meetingMembers, setMeetingMembers] = useState<IMeetingUser[]>([]);
   const pcs = useRef<{ [socketID: string]: RTCPeerConnection }>({});
   const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
-
-  const applyDeviceStatus = useCallback(
-    ({ stream, video, audio }: { stream: MediaStream; video: boolean; audio: boolean }) => {
-      stream?.getVideoTracks().forEach((track) => {
-        track.enabled = video;
-      });
-      stream?.getAudioTracks().forEach((track) => {
-        track.enabled = audio;
-      });
-    },
-    [],
-  );
 
   const getMyStream = async () => {
     let myStream;
@@ -172,7 +177,7 @@ function MeetVideo() {
         );
         screenSenders.forEach((sender) => pc.removeTrack(sender));
       });
-      myScreenStreamRef.current = null;
+      myScreenStreamRef.current = undefined;
     }
   }, [screenShare]);
 

--- a/client/src/components/Meet/index.tsx
+++ b/client/src/components/Meet/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MeetVideo from './MeetVideo';
-import MeetButton from './MeetButton';
+import MeetButton from './MeetVideo/MeetButton';
 import { MeetWrapper, VideoSection } from './style';
 import MeetChat from './MeetChat';
 
@@ -10,7 +10,6 @@ function Meet() {
       <MeetChat />
       <VideoSection>
         <MeetVideo />
-        <MeetButton />
       </VideoSection>
     </MeetWrapper>
   );

--- a/client/src/utils/audio.ts
+++ b/client/src/utils/audio.ts
@@ -1,36 +1,40 @@
 const highlightMyVolume = (stream: MediaStream, myVideo: HTMLVideoElement) => {
-  const audioContext = new AudioContext();
-  const analyser = audioContext.createAnalyser();
-  const microphone = audioContext.createMediaStreamSource(stream);
-  const javascriptNode = audioContext?.createScriptProcessor(2048, 1, 1);
-  analyser.smoothingTimeConstant = 0.2;
-  analyser.fftSize = 1024;
+  try {
+    const audioContext = new AudioContext();
+    const analyser = audioContext.createAnalyser();
+    const microphone = audioContext.createMediaStreamSource(stream);
+    const javascriptNode = audioContext?.createScriptProcessor(2048, 1, 1);
+    analyser.smoothingTimeConstant = 0.2;
+    analyser.fftSize = 1024;
 
-  let check = true;
-  const interval = 1000;
+    let check = true;
+    const interval = 1000;
 
-  microphone.connect(analyser);
-  analyser.connect(javascriptNode);
-  javascriptNode.connect(audioContext.destination);
-  javascriptNode.onaudioprocess = () => {
-    if (!check) return;
-    const array = new Uint8Array(analyser.frequencyBinCount);
-    analyser.getByteFrequencyData(array);
+    microphone.connect(analyser);
+    analyser.connect(javascriptNode);
+    javascriptNode.connect(audioContext.destination);
+    javascriptNode.onaudioprocess = () => {
+      if (!check) return;
+      const array = new Uint8Array(analyser.frequencyBinCount);
+      analyser.getByteFrequencyData(array);
 
-    const length = array.length;
-    const values = array.reduce((acu, v) => acu + v, 0);
-    const average = values / length;
-    const minimumVolume = 30;
-    if (Math.round(average) > minimumVolume) {
-      myVideo.classList.add('saying');
-      check = false;
-      setTimeout(() => {
-        check = true;
-      }, interval);
-    } else {
-      myVideo.classList.remove('saying');
-    }
-  };
+      const length = array.length;
+      const values = array.reduce((acu, v) => acu + v, 0);
+      const average = values / length;
+      const minimumVolume = 30;
+      if (Math.round(average) > minimumVolume) {
+        myVideo.classList.add('saying');
+        check = false;
+        setTimeout(() => {
+          check = true;
+        }, interval);
+      } else {
+        myVideo.classList.remove('saying');
+      }
+    };
+  } catch (e) {
+    console.error(e);
+  }
 };
 
 export { highlightMyVolume };


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #206 
- close #214 
## What did you do?

기존 코드에서는 getMyStream을 별도 useEffect에서 호출하고 있어 rtc 연결시 생성됨을 보장할 수 없었습니다.
그래서 RTC 연결을 시작하는 코드 앞단으로 getMyStream 호출을 옮겨 스트림 생성이 끝난 후 연결을 진행하도록 했습니다.

미디어 스트림들을 useState를 이용해 관리하고 있어 최신 stream 상태를 참조하기 위해 리렌더링 후 stream 상태를 참조하는 effect들을 모두 다시실행해주었어야 했습니다. 이를 useRef를 이용해 관리함으로써 리렌더링을 줄이고, effect를 채널 id가 바뀌는 경우(채널을 이동하는 경우)에만 다시 실행하도록 해 stream 상태 변경시(undefined =>  끊고 재연결 하지 않게 되었습니다.

화상 채널을 나가는 경우 트랙을 종료시키지 않아 브라우저에 녹화 표시가 계속 나타나던 문제를 수정했습니다.
RTC연결을 처리하는 useEffect의 클린업 함수에서 각 stream(캠, 화면공유)의 트랙을 모두 멈춰주도록해 해결했습니다.

<!--무엇을 하셨나요?-->
- [x] 화면 공유 버튼을 눌러 화면을 공유할 수 있습니다.
- [x] 스트림 생성 후 연결을 보장받도록 코드를 수정했습니다.
- [x] 리렌더링 발생시 rtc 연결을 끊고 재연결 하지 않도록 개선했습니다
- [x] 화상채널을 나가도 스트림이 종료되지 않아 브라우저에 녹화표시가 계속 나타나던 것을 고쳤습니다.
- [x] 비동기 함수들에 try/catch를 이용한 에러처리가 누락되어 있던 것을 수정  

## 팀원들에게 하고 싶은 말
<!--+ 팀원들에게 할 말-->
아직 개선해야할 부분이 산더미입니다... 코드도 나눠야하고 변수, 컴포넌트 등의 이름도 적절하게 다시 지어줘야 합니다.
또 아직 클릭해서 해당 비디오를 큰 화면으로 보는 기능을 구현하지 않아 반쪽짜리입니다 ㅠㅠ
오늘안에 모두 해결해볼께요!

그리고 입력 기기(캠/마이크) 선택... 기능 추가해야합니다!

## 레퍼런스
<!--참고한 자료가 있나요?-->
https://developer.mozilla.org/ko/docs/Web/API/RTCPeerConnection/addTrack
https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling
https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
https://stackoverflow.com/questions/25141080/how-to-listen-for-stop-sharing-click-in-chrome-desktopcapture-api
