### PR TITLE
Fix : url변경시 history push대신 replace 사용하도록 수정

### DIFF
--- a/client/src/components/Modal/ChannelCreate/index.tsx
+++ b/client/src/components/Modal/ChannelCreate/index.tsx
@@ -49,7 +49,7 @@ export default function ChannelCreateModal({
       }, false);
       controller.hide();
       if (channelType === 'chatting') {
-        history.push(URL.channelPage(selectedGroup.id, channelType, createdChannel.id));
+        history.replace(URL.channelPage(selectedGroup.id, channelType, createdChannel.id));
         dispatch(
           setSelectedChannel({
             type: channelType,

--- a/client/src/components/Modal/GroupCreate/index.tsx
+++ b/client/src/components/Modal/GroupCreate/index.tsx
@@ -43,7 +43,7 @@ function GroupCreateModal({
         mutate([...groups, group], false);
         dispatch(setSelectedGroup(group));
         finishModal();
-        history.push(URL.groupPage(group.id));
+        history.replace(URL.groupPage(group.id));
         break;
       case 400:
         const responseText = await response.text();

--- a/client/src/components/Modal/GroupDelete/index.tsx
+++ b/client/src/components/Modal/GroupDelete/index.tsx
@@ -40,7 +40,7 @@ function GroupDeleteModal({ controller: { hide, show } }: { controller: ModalCon
           );
           dispatch(setSelectedChat(null));
           hide();
-          history.push(URL.groupPage());
+          history.replace(URL.groupPage());
           break;
         case 400:
           const responseText = await response.text();

--- a/client/src/components/Modal/GroupJoin/index.tsx
+++ b/client/src/components/Modal/GroupJoin/index.tsx
@@ -32,7 +32,7 @@ function GroupJoinModal({ controller: { hide, show, previous } }: { controller: 
         mutate([...groups, group], false);
         dispatch(setSelectedGroup(group));
         finishModal();
-        history.push(URL.groupPage(group.id));
+        history.replace(URL.groupPage(group.id));
         break;
       case 400:
         const responseText = await response.text();

--- a/client/src/components/Modal/Logout/index.tsx
+++ b/client/src/components/Modal/Logout/index.tsx
@@ -12,7 +12,7 @@ function LogoutModal({ controller: { hide, show } }: { controller: ModalControll
   const finishModal = () => hide();
   const logOut = async () => {
     const isSuccess = await postLogout();
-    if (isSuccess) history.push(URL.loginPage);
+    if (isSuccess) history.replace(URL.loginPage);
     window.location.reload();
   };
 

--- a/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
+++ b/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
@@ -22,7 +22,7 @@ function ChannelListItem({ channelType, meetingUserCount, id, name }: Props) {
 
   const joinChannel = () => {
     if (meetingUserCount >= 5 && channelType === 'meeting') return;
-    history.push(URL.channelPage(selectedGroup?.id, channelType, id));
+    history.replace(URL.channelPage(selectedGroup?.id, channelType, id));
     dispatch(setSelectedChannel({ type: channelType, id, name }));
   };
 

--- a/client/src/components/SideBar/GroupNav/index.tsx
+++ b/client/src/components/SideBar/GroupNav/index.tsx
@@ -45,7 +45,7 @@ function GroupNav() {
   };
 
   const selectGroup = (group: any) => () => {
-    history.push(URL.groupPage(group.id));
+    history.replace(URL.groupPage(group.id));
     dispatch(setSelectedChannel({ type: '', id: null, name: '' }));
     dispatch(setSelectedGroup(group));
     socket.emit(GroupEvent.groupID, group.code);
@@ -71,7 +71,7 @@ function GroupNav() {
           }),
         );
         dispatch(setSelectedChat(null));
-        history.push(URL.groupPage());
+        history.replace(URL.groupPage());
       }
     });
 

--- a/client/src/hooks/useAccessControl.ts
+++ b/client/src/hooks/useAccessControl.ts
@@ -17,6 +17,6 @@ export const useAccessControl = ({
   useEffect(() => {
     if (isValidating) return;
     const isAccessible = (signIn && userdata) || (!signIn && !userdata);
-    if (!isAccessible) history.push(redirectPath);
+    if (!isAccessible) history.replace(redirectPath);
   }, [isValidating, userdata, history, signIn, redirectPath]);
 };

--- a/client/src/pages/SignIn/index.tsx
+++ b/client/src/pages/SignIn/index.tsx
@@ -47,7 +47,7 @@ function SignIn() {
 
     try {
       const loginResponse = await tryLogin(ID, password);
-      if (loginResponse.status === STATUS_CODES.OK) history.push(URL.groupPage());
+      if (loginResponse.status === STATUS_CODES.OK) history.replace(URL.groupPage());
       setResponseState({ ...responseState, ...loginResponse });
     } catch (error) {
       console.log(error);

--- a/client/src/pages/SignIn/index.tsx
+++ b/client/src/pages/SignIn/index.tsx
@@ -78,7 +78,7 @@ function SignIn() {
           <ErrorResponse>{checkLogin(status, responseText)}</ErrorResponse>
           <SignUpPart>
             <p>계정이 필요한가요?</p>
-            <Link to="/signup">
+            <Link to="/signup" replace>
               <p>가입하기</p>
             </Link>
           </SignUpPart>

--- a/client/src/pages/SignUp/index.tsx
+++ b/client/src/pages/SignUp/index.tsx
@@ -120,7 +120,9 @@ function SignUp() {
             <p>가입하기</p>
           </SignUpButton>
           <div>
-            <Link to="/">이미 계정이 있으신가요?</Link>
+            <Link to="/" replace>
+              이미 계정이 있으신가요?
+            </Link>
           </div>
         </ButtonWrapper>
       </SignUpWrapper>


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #260 
## What did you do?
 기존에 history에 push 해주는 방식은 그룹/채널 이동시마다 history가 쌓여 사용자가 Duxcord에 오기전 있었던 페이지로 돌아가기 힘들듭니다. 뿐만아니라 SPA 특성상 브라우저에서 뒤로가기를 눌러 url이 바뀌어도 새 페이지를 요청해 불러오는 것이 아니기 때문에 별도 조치가 없다면, 기존 상태가 유지됩니다.  따라서 채널을 변경해 url이 바뀐 후 뒤로가기를 눌러도 이전 채널로 돌아가지지 않습니다. 이는 사용자 경험에 좋지 않다고 판단되어 replace를 이용해 history 가 쌓이지 않게 replace를 사용하도록 수정했습니다.

<!--무엇을 하셨나요?-->
- [x] Link 컴포넌트에 replace 속성 추가
- [x] history.push => history.replace로 수정

