### PR TITLE
style: 그룹 목록 애니메이션 적용

### DIFF
--- a/client/src/components/SideBar/GroupNav/index.tsx
+++ b/client/src/components/SideBar/GroupNav/index.tsx
@@ -7,7 +7,14 @@ import { setSelectedGroup } from '@redux/selectedGroup/slice';
 import { setSelectedChat } from '@redux/selectedChat/slice';
 import GroupJoinModal from '../../Modal/GroupJoin';
 import { socket } from '../../../utils/socket';
-import { GroupListWrapper, GroupList, Group, GroupListDivider, AddGroupButton } from './style';
+import {
+  GroupListWrapper,
+  GroupList,
+  GroupWrapper,
+  Group,
+  GroupListDivider,
+  AddGroupButton,
+} from './style';
 import { ModalController } from '@customTypes/modal';
 import {
   addUserConnection,
@@ -96,9 +103,11 @@ function GroupNav() {
     <GroupListWrapper>
       <GroupList>
         {groups?.map((group: any) => (
-          <Group key={group.id} onClick={selectGroup(group)} thumbnail={group.thumbnail}>
-            {!group.thumbnail && group.name}
-          </Group>
+          <GroupWrapper name={group.name}>
+            <Group key={group.id} onClick={selectGroup(group)} thumbnail={group.thumbnail}>
+              <p>{!group.thumbnail && group.name}</p>
+            </Group>
+          </GroupWrapper>
         ))}
       </GroupList>
       <GroupListDivider />

--- a/client/src/components/SideBar/GroupNav/style.ts
+++ b/client/src/components/SideBar/GroupNav/style.ts
@@ -6,6 +6,32 @@ const radiusChange = keyframes`
   to { border-radius: 30%; }
 `;
 
+const colorChange = keyframes`
+  from {
+    border-radius: 50%;
+    background-color: ${Colors.White};
+  }
+  to {
+    border-radius: 30%;
+    background-color: ${Colors.Blue};
+  }
+`;
+
+const colorIconChange = keyframes`
+  from { stroke: ${Colors.Blue}; }
+  to { stroke: ${Colors.White}; }
+`;
+
+const colorTextChange = keyframes`
+  from { color: ${Colors.Black}; }
+  to { color: ${Colors.White}; }
+`;
+
+const nameShow = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
 const GroupListWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -25,9 +51,6 @@ const GroupListDivider = styled.div`
 `;
 
 const GroupList = styled.div`
-  & div:not(:last-child) {
-    margin-bottom: 10px;
-  }
   overflow-y: scroll;
   height: 100%;
   -ms-overflow-style: none;
@@ -37,9 +60,31 @@ const GroupList = styled.div`
   }
 `;
 
+interface IGroupWrapper {
+  name: string;
+}
+
 interface IGroup {
   thumbnail: string | null;
 }
+
+const GroupWrapper = styled.div<IGroupWrapper>`
+  display: flex;
+  position: relative;
+  align-items: center;
+  margin: 10px 0;
+  width: 48px;
+  height: 48px;
+  &:hover:after {
+    content: '${(props) => props.name}';
+    position: fixed;
+    left: 70px;
+    background-color: ${Colors.White};
+    padding: 12px;
+    border-radius: 6px;
+    animation: ${nameShow} 0.1s linear both;
+  }
+`;
 
 const Group = styled.div<IGroup>`
   display: flex;
@@ -53,11 +98,20 @@ const Group = styled.div<IGroup>`
   overflow: hidden;
   ${(props) =>
     props.thumbnail
-      ? `background-image: url('${props.thumbnail}'); background-size: cover; background-repeat: no-repeat;background-position-x: center;background-position-y: center; `
+      ? `
+        background-image: url('${props.thumbnail}');
+        background-size: cover;
+        background-repeat: no-repeat;
+        background-position-x: center;
+        background-position-y: center;
+      `
       : `background-color: ${Colors.White};`}
   &:hover {
     cursor: pointer;
-    animation: ${radiusChange} 0.1s linear both;
+    animation: ${(props) => (props.thumbnail ? radiusChange : colorChange)} 0.1s linear both;
+    & p {
+      animation: ${colorTextChange} 0.1s linear both;
+    }
   }
 `;
 
@@ -72,12 +126,18 @@ const AddGroupButton = styled.button`
   background-color: ${Colors.White};
   &:hover {
     cursor: pointer;
-    animation: ${radiusChange} 0.1s linear both;
+    animation: ${colorChange} 0.1s linear both;
+    & path {
+      animation: ${colorIconChange} 0.1s linear both;
+    }
   }
   & svg {
-    width: 48px;
-    height: 48px;
+    width: 30px;
+    height: 30px;
+    & path {
+      stroke: ${Colors.Blue};
+    }
   }
 `;
 
-export { GroupListWrapper, GroupList, Group, GroupListDivider, AddGroupButton };
+export { GroupListWrapper, GroupList, GroupWrapper, Group, GroupListDivider, AddGroupButton };


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #262 

## What did you do?

<!--무엇을 하셨나요?-->
- [x]  그룹 목록 애니메이션 구현
- [x] 그룹에 마우스 올리면 그룹 이름 보이도록 스타일 적용

![Nov-18-2021 16-17-58](https://user-images.githubusercontent.com/73640737/142370081-fccaa76f-e22b-4654-824a-c59a724ca027.gif)

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
그룹 이름을 fixed로 했더니 그룹을 스크롤하면 제대로 안뜨네요 해결해주실분..

## 레퍼런스
<!--참고한 자료가 있나요?-->

