### PR TITLE
hotfix : 화상 회의 채널 채팅을 열었을 때 스크롤이 바로 최하단으로 가지 않고 부드럽게 내려가던 것을 수정

### DIFF
--- a/client/src/components/Meet/MeetChat/index.tsx
+++ b/client/src/components/Meet/MeetChat/index.tsx
@@ -46,13 +46,16 @@ function MeetChat() {
     chatInputRef.current.value = '';
   };
 
-  const scrollToBottom = () => {
+  const scrollToBottom = ({ smooth }: { smooth: boolean }) => {
     if (!chatListRef.current) return;
-    chatListRef.current.scrollTo({ top: chatListRef.current.scrollHeight, behavior: 'smooth' });
+    chatListRef.current.scrollTo({
+      top: chatListRef.current.scrollHeight,
+      behavior: smooth ? 'smooth' : 'auto',
+    });
   };
 
   useLayoutEffect(() => {
-    scrollToBottom();
+    scrollToBottom({ smooth: false });
   }, [show]);
 
   useEffect(() => {
@@ -60,7 +63,7 @@ function MeetChat() {
       setChats((chats) => [...chats, chat]);
       if (!chatListRef.current) return;
       const { scrollTop, clientHeight, scrollHeight } = chatListRef.current;
-      if (scrollHeight - (scrollTop + clientHeight) < THRESHOLD) scrollToBottom();
+      if (scrollHeight - (scrollTop + clientHeight) < THRESHOLD) scrollToBottom({ smooth: true });
     });
 
     return () => {


### PR DESCRIPTION
## What did you do?
화상 회의 채널 채팅을 열었을 때 스크롤이 바로 최하단으로 가지 않고 부드럽게 내려가던 것을 수정했습니다.
더 이상 최신 메시지를 보기 위해 기다릴 필요가 없습니다.
<!--무엇을 하셨나요?-->
- [x]  화상 회의 채널 채팅을 열엇을 때 스크롤이 바로 맨 아래로 내려가도록 수정