### PR TITLE
Hotfix : 화상 회의 채널 캠 오프시 프로필 이미지가 원본사이즈로 표시되는 문제 수정

### DIFF
--- a/client/src/components/Meet/MeetChat/style.ts
+++ b/client/src/components/Meet/MeetChat/style.ts
@@ -76,6 +76,7 @@ const ShowChatButton = styled.button`
   top: 10px;
   background: none;
   border: none;
+  z-index: 10;
 
   svg {
     width: 25px;

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -1,7 +1,7 @@
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
 import { useRef, useEffect } from 'react';
 import { IMeetingUser } from '..';
-import { VideoItemWrapper, VideoItem } from '../style';
+import { VideoItemWrapper, VideoItem, Thumbnail } from '../style';
 
 function OtherVideo({
   member: { socketID, loginID, username, thumbnail, cam, speaker, mic, stream, screen, pc },
@@ -47,7 +47,9 @@ function OtherVideo({
         <p>{`${username}(${loginID})`}</p>
         {mic || <MicOffIcon />}
         {speaker || <SpeakerOffIcon />}
-        {cam || <img src={thumbnail || '/images/default_profile.png'} alt="profile"></img>}
+        {cam || (
+          <Thumbnail src={thumbnail || '/images/default_profile.png'} alt="profile"></Thumbnail>
+        )}
       </VideoItemWrapper>
       {screen && (
         <VideoItemWrapper>

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import MeetEvent from '@customTypes/socket/MeetEvent';
 import { useSelectedChannel, useSelectedGroup, useUserdata, useUserDevice } from '@hooks/index';
 import Socket, { socket } from '../../../utils/socket';
-import { MeetVideoWrapper, VideoItemWrapper, VideoItem, MyImage } from './style';
+import { MeetVideoWrapper, VideoItemWrapper, VideoItem, Thumbnail } from './style';
 import { highlightMyVolume } from '../../../utils/audio';
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
 import OtherVideo from './OtherVideo';
@@ -322,7 +322,7 @@ function MeetVideo() {
           {cam ? (
             ''
           ) : (
-            <MyImage src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
+            <Thumbnail src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
           )}
           <p>{`${userdata?.username}(${userdata?.loginID})`}</p>
           {mic ? '' : <MicOffIcon />}

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -44,7 +44,10 @@ const VideoItemWrapper = styled.div`
   }
 `;
 
-const MyImage = styled.img`
+const Thumbnail = styled.img`
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
   position: absolute;
 `;
 
@@ -57,4 +60,4 @@ const VideoItem = styled.video`
   margin-bottom: 10px;
 `;
 
-export { MeetVideoWrapper, VideoItemWrapper, VideoItem, MyImage };
+export { MeetVideoWrapper, VideoItemWrapper, VideoItem, Thumbnail };

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -48,6 +48,7 @@ const Thumbnail = styled.img`
   width: 100px;
   height: 100px;
   object-fit: cover;
+  border-radius: 50%;
   position: absolute;
 `;
 


### PR DESCRIPTION
## What did you do?
화상 회의 채널 캠 오프시 프로필 이미지가 원본사이즈로 표시되어 다른 요소를 가리던 문제 수정.
사이즈를 100px * 100px로 제한하고 object-fit: cover 속성값을 줘 비율이 안깨지도록 함
화상 회의 채널 채팅 버튼이 다른 요소에 가려지지 않도록 z-index 부여
<!--무엇을 하셨나요?-->
- [x] 화상 회의 채널 캠 오프시 띄워주는 프로필 이미지 사이즈 제한
- [x] 화상 회의 채널 버튼 z-index 부여

## 레퍼런스
<!--참고한 자료가 있나요?-->
https://developer.mozilla.org/ko/docs/Web/CSS/object-fit
