### PR TITLE
refactor: 임포트 시 alias가 제대로 먹지 않은 부분 수정, 임포트 순서 변경

### DIFF
--- a/client/src/components/ChannelHeader/index.tsx
+++ b/client/src/components/ChannelHeader/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+
 import { useSelectedChannel } from '@hooks/index';
 import { ModalController } from '@customTypes/modal';
+import LogoutModal from '../Modal/Logout';
 import {
   ChannelChattingIcon,
   ChannelMeetingIcon,
@@ -8,7 +10,6 @@ import {
   HeaderFixIcon,
   HeaderUsersIcon,
 } from '../common/Icons';
-import LogoutModal from '../Modal/Logout';
 import { ChannelHeaderWrapper, ChannelHeaderLeft, ChannelHeaderRight } from './style';
 
 function ChannelHeader() {

--- a/client/src/components/Chat/AddChatReaction/index.tsx
+++ b/client/src/components/Chat/AddChatReaction/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LikeIcon, ThreadOpenIcon } from '../../common/Icons';
 import { Wrapper } from './style';
 

--- a/client/src/components/Chat/ChatInput/index.tsx
+++ b/client/src/components/Chat/ChatInput/index.tsx
@@ -1,9 +1,10 @@
 import React, { FormEvent, useRef, useState } from 'react';
-import { postChat } from '../../../api/postChat';
+
 import { useSelectedChannel } from '@hooks/index';
-import { FileSelectIcon } from '../../common/Icons';
-import { FileInputWrapper, ChatInputWrapper, Wrapper } from './style';
+import { postChat } from 'src/api/postChat';
 import { uploadFileToStorage } from 'src/utils/uploadFile';
+import { FileSelectIcon } from '@components/common/Icons';
+import { FileInputWrapper, ChatInputWrapper, Wrapper } from './style';
 
 function ChatInput({ scrollToBottom }: { scrollToBottom: () => void }) {
   const { id } = useSelectedChannel();

--- a/client/src/components/Chat/ChatItem/index.tsx
+++ b/client/src/components/Chat/ChatItem/index.tsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { postLikeChat } from '../../../api/postLikeChat';
-import { STATUS_CODES } from '../../../api/STATUS_CODES';
+
 import { setSelectedChat } from '@redux/selectedChat/slice';
 import { setSelectedUser } from '@redux/selectedUser/slice';
+import { useUserdata } from '@hooks/index';
 import { ChatData } from '@customTypes/chats';
+import { postLikeChat } from 'src/api/postLikeChat';
+import { STATUS_CODES } from 'src/api/STATUS_CODES';
 import ThreadPreview from '../ThreadPreview';
 import AddChatReaction from '../AddChatReaction';
 import ChatReaction from '../ChatReaction';
-import { useUserdata } from '@hooks/index';
 import { ChatWrapper, UserImage, FileWrapper, ChatHeader, ChatContent } from './style';
 
 function ChatItem({ chatData }: { chatData: ChatData }) {

--- a/client/src/components/Chat/ChatReaction/index.tsx
+++ b/client/src/components/Chat/ChatReaction/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Wrapper } from './style';
 
 function ChatReaction({

--- a/client/src/components/Chat/Thread/index.tsx
+++ b/client/src/components/Chat/Thread/index.tsx
@@ -1,16 +1,18 @@
 import React, { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import useSWR from 'swr';
-import { API_URL } from '../../../api/API_URL';
-import { postCreateThread } from '../../../api/postCreateThread';
-import { useSelectedChannel } from '@hooks/index';
+
 import { setSelectedChat } from '@redux/selectedChat/slice';
+import { useSelectedChannel } from '@hooks/index';
 import { ChatData } from '@customTypes/chats';
-import { getFetcher } from '../../../utils/fetcher';
-import { socket } from '../../../utils/socket';
 import ChannelEvent from '@customTypes/socket/ChannelEvent';
-import { ThreadCloseIcon } from '../../common/Icons';
+import ThreadType from '@customTypes/socket/ThreadEvent';
+import { API_URL } from 'src/api/API_URL';
+import { postCreateThread } from 'src/api/postCreateThread';
+import { getFetcher } from 'src/utils/fetcher';
+import { socket } from 'src/utils/socket';
 import ThreadItem from '../ThreadItem';
+import { ThreadCloseIcon } from '../../common/Icons';
 import {
   Input,
   InputWrapper,
@@ -21,7 +23,6 @@ import {
   ThreadChatWrapper,
   ChatLengthWrapper,
 } from './style';
-import ThreadType from '@customTypes/socket/ThreadEvent';
 
 function Thread({ selectedChat }: { selectedChat: ChatData }) {
   const { mutate, data } = useSWR(API_URL.thread.getThread(selectedChat.id), getFetcher);

--- a/client/src/components/Chat/ThreadItem/index.tsx
+++ b/client/src/components/Chat/ThreadItem/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ThreadData } from '@customTypes/threads';
 import { Wrapper } from './style';
 

--- a/client/src/components/Chat/ThreadPreview/index.tsx
+++ b/client/src/components/Chat/ThreadPreview/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { User } from '@customTypes/chats';
 import { ThreadPreviewWrapper } from './style';
 

--- a/client/src/components/Chat/UserConnection/index.tsx
+++ b/client/src/components/Chat/UserConnection/index.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect } from 'react';
 import useSWR from 'swr';
 import { useDispatch } from 'react-redux';
-import { API_URL } from '../../../api/API_URL';
-import GroupEvent from '@customTypes/socket/GroupEvent';
-import { useGroupConnection, useSelectedGroup, useUserdata } from '@hooks/index';
-import { getFetcher } from '../../../utils/fetcher';
-import { socket } from '../../../utils/socket';
-import { UserConnectionWrapper, Text, UserImage, UserTile } from './style';
+
 import { setSelectedUser } from '@redux/selectedUser/slice';
+import { useGroupConnection, useSelectedGroup, useUserdata } from '@hooks/index';
+import GroupEvent from '@customTypes/socket/GroupEvent';
+import { API_URL } from 'src/api/API_URL';
+import { getFetcher } from 'src/utils/fetcher';
+import { socket } from 'src/utils/socket';
+import { UserConnectionWrapper, Text, UserImage, UserTile } from './style';
 
 function UserConnection() {
   const selectedGroup = useSelectedGroup();

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -1,18 +1,19 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import ChatItem from './ChatItem';
-import { ChatContainer, Chats, ChatPart, ChatInputWrapper } from './style';
-import { ChatData } from '@customTypes/chats';
-import ChatInput from './ChatInput';
 import useSWRInfinite from 'swr/infinite';
-import Socket, { socket } from '../../utils/socket';
-import { getFetcher } from '../../utils/fetcher';
-import UserConnection from './UserConnection';
-import Thread from './Thread';
-import { API_URL } from '../../api/API_URL';
+
+import { useSelectedChannel, useSelectedChat } from '@hooks/index';
 import LikeEvent from '@customTypes/socket/LikeEvent';
 import ThreadEvent from '@customTypes/socket/ThreadEvent';
 import ChatEvent from '@customTypes/socket/ChatEvent';
-import { useSelectedChannel, useSelectedChat } from '@hooks/index';
+import { ChatData } from '@customTypes/chats';
+import { API_URL } from 'src/api/API_URL';
+import Socket, { socket } from 'src/utils/socket';
+import { getFetcher } from 'src/utils/fetcher';
+import ChatInput from './ChatInput';
+import ChatItem from './ChatItem';
+import UserConnection from './UserConnection';
+import Thread from './Thread';
+import { ChatContainer, Chats, ChatPart, ChatInputWrapper } from './style';
 
 const PAGE_SIZE = 20;
 const THRESHOLD = 300;

--- a/client/src/components/Meet/MeetChat/index.tsx
+++ b/client/src/components/Meet/MeetChat/index.tsx
@@ -1,8 +1,9 @@
 import React, { FormEvent, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import MeetEvent from '@customTypes/socket/MeetEvent';
+
 import { useSelectedChannel, useUserdata } from '@hooks/index';
-import { socket } from '../../../utils/socket';
-import { ChatCloseIcon, ChatOpenIcon } from '../../common/Icons';
+import MeetEvent from '@customTypes/socket/MeetEvent';
+import { socket } from 'src/utils/socket';
+import { ChatCloseIcon, ChatOpenIcon } from '@components/common/Icons';
 import {
   Chat,
   ChatList,

--- a/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
+++ b/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { MeetingStopIcon, ScreenShareStartIcon } from '../../../common/Icons';
+
+import { MeetingStopIcon, ScreenShareStartIcon } from '@components/common/Icons';
 import { MeetButtonWrapper } from './style';
 
 function MeetButton({ onClick }: { onClick: () => void }) {

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -1,5 +1,6 @@
+import React, { useRef, useEffect } from 'react';
+
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import { useRef, useEffect } from 'react';
 import { IMeetingUser } from '..';
 import { VideoItemWrapper, VideoItem, Thumbnail } from '../style';
 

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -1,12 +1,13 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import MeetEvent from '@customTypes/socket/MeetEvent';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+
 import { useSelectedChannel, useSelectedGroup, useUserdata, useUserDevice } from '@hooks/index';
-import Socket, { socket } from '../../../utils/socket';
-import { MeetVideoWrapper, VideoItemWrapper, VideoItem, Thumbnail } from './style';
-import { highlightMyVolume } from '../../../utils/audio';
-import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
+import MeetEvent from '@customTypes/socket/MeetEvent';
+import Socket, { socket } from 'src/utils/socket';
+import { highlightMyVolume } from 'src/utils/audio';
 import OtherVideo from './OtherVideo';
 import MeetButton from './MeetButton';
+import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
+import { MeetVideoWrapper, VideoItemWrapper, VideoItem, Thumbnail } from './style';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
 

--- a/client/src/components/Meet/index.tsx
+++ b/client/src/components/Meet/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+
 import MeetVideo from './MeetVideo';
-import MeetButton from './MeetVideo/MeetButton';
-import { MeetWrapper, VideoSection } from './style';
 import MeetChat from './MeetChat';
+import { MeetWrapper, VideoSection } from './style';
 
 function Meet() {
   return (

--- a/client/src/components/Modal/ChannelCreate/ChannelTypeItem/index.tsx
+++ b/client/src/components/Modal/ChannelCreate/ChannelTypeItem/index.tsx
@@ -1,6 +1,7 @@
+import React, { ReactElement } from 'react';
+
 import { CircleDeselectedIcon, CircleSelectedIcon } from '@components/common/Icons';
 import { Wrapper, Title, SubTitle } from './style';
-import React, { ReactElement } from 'react';
 
 export default function ChannelTypeItem({
   isSelected,

--- a/client/src/components/Modal/ChannelCreate/index.tsx
+++ b/client/src/components/Modal/ChannelCreate/index.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
+
+import { setSelectedChannel } from '@redux/selectedChannel/slice';
+import { useSelectedGroup, useGroups } from '@hooks/index';
 import { ModalController } from '@customTypes/modal';
 import Colors from '@styles/Colors';
+import { postCreateChannel } from 'src/api/postCreateChannel';
+import { URL } from 'src/api/URL';
 import Modal from '..';
 import ChannelTypeItem from './ChannelTypeItem';
 import { ChannelChattingIcon, ChannelMeetingIcon } from '@components/common/Icons';
 import { Label, Wrapper, Input, ErrorMessage } from './style';
-import { postCreateChannel } from 'src/api/postCreateChannel';
-import { useSelectedGroup } from '@hooks/useSelectedGroup';
-import { useGroups } from '@hooks/useGroups';
-import { useHistory } from 'react-router';
-import { URL } from 'src/api/URL';
-import { setSelectedChannel } from '@redux/selectedChannel/slice';
-import { useDispatch } from 'react-redux';
 
 export default function ChannelCreateModal({
   initialChannelType,

--- a/client/src/components/Modal/GroupAdd/index.tsx
+++ b/client/src/components/Modal/GroupAdd/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Modal from '..';
+
 import { ModalController } from '@customTypes/modal';
+import Modal from '..';
 import { Transporter } from './style';
 
 function GroupAddModal({

--- a/client/src/components/Modal/GroupCreate/index.tsx
+++ b/client/src/components/Modal/GroupCreate/index.tsx
@@ -1,16 +1,17 @@
 import React, { useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
-import Modal from '..';
-import { postCreateGroup } from '../../../api/postCreateGroup';
-import { useGroups } from '@hooks/index';
+
 import { setSelectedGroup } from '@redux/selectedGroup/slice';
-import Colors from '@styles/Colors';
+import { useGroups } from '@hooks/index';
 import { ModalController } from '@customTypes/modal';
-import { ErrorDiv, InputForm, InputImage, InputText } from './style';
+import Colors from '@styles/Colors';
 import { URL } from 'src/api/URL';
+import { postCreateGroup } from 'src/api/postCreateGroup';
 import { uploadFileToStorage } from 'src/utils/uploadFile';
-import { GroupThumbnailUploadIcon } from '../../common/Icons';
+import Modal from '..';
+import { GroupThumbnailUploadIcon } from '@components/common/Icons';
+import { ErrorDiv, InputForm, InputImage, InputText } from './style';
 
 function GroupCreateModal({
   controller: { hide, show, previous },

--- a/client/src/components/Modal/GroupDelete/index.tsx
+++ b/client/src/components/Modal/GroupDelete/index.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
-import Modal from '..';
-import { deleteGroup } from '../../../api/deleteGroup';
-import { useSelectedGroup, useGroups } from '@hooks/index';
+
 import { setSelectedGroup } from '@redux/selectedGroup/slice';
 import { setSelectedChannel } from '@redux/selectedChannel/slice';
 import { setSelectedChat } from '@redux/selectedChat/slice';
-import Colors from '@styles/Colors';
+import { useSelectedGroup, useGroups } from '@hooks/index';
 import { ModalController } from '@customTypes/modal';
-import { AlertWrapper } from './style';
-import { URL } from 'src/api/URL';
-import { socket } from '../../../utils/socket';
 import GroupEvent from '@customTypes/socket/GroupEvent';
+import Colors from '@styles/Colors';
+import { URL } from 'src/api/URL';
+import { deleteGroup } from 'src/api/deleteGroup';
+import { socket } from 'src/utils/socket';
+import Modal from '..';
+import { AlertWrapper } from './style';
 
 function GroupDeleteModal({ controller: { hide, show } }: { controller: ModalController }) {
   const selectedGroup = useSelectedGroup();

--- a/client/src/components/Modal/GroupInvite/index.tsx
+++ b/client/src/components/Modal/GroupInvite/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import Modal from '..';
+
 import { useSelectedGroup } from '@hooks/index';
-import Colors from '@styles/Colors';
 import { ModalController } from '@customTypes/modal';
+import Colors from '@styles/Colors';
+import Modal from '..';
 import { CodeWrapper } from './style';
 
 const pasteCodeMessage = {

--- a/client/src/components/Modal/GroupJoin/index.tsx
+++ b/client/src/components/Modal/GroupJoin/index.tsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
-import Modal from '..';
-import { postJoinGroup } from '../../../api/postJoinGroup';
+
 import { useGroups } from '@hooks/index';
 import { setSelectedGroup } from '@redux/selectedGroup/slice';
 import Colors from '@styles/Colors';
 import { ModalController } from '@customTypes/modal';
-import { Input } from './style';
+import { postJoinGroup } from 'src/api/postJoinGroup';
 import { URL } from 'src/api/URL';
+import Modal from '..';
+import { Input } from './style';
 
 function GroupJoinModal({ controller: { hide, show, previous } }: { controller: ModalController }) {
   const [groupCode, setGroupCode] = useState('');

--- a/client/src/components/Modal/Logout/index.tsx
+++ b/client/src/components/Modal/Logout/index.tsx
@@ -1,11 +1,12 @@
+import React from 'react';
 import { useHistory } from 'react-router';
-import Modal from '..';
-import { ModalController } from '@customTypes/modal';
 
+import { ModalController } from '@customTypes/modal';
 import Colors from '@styles/Colors';
-import { MiddlePart } from './style';
-import { postLogout } from '../../../api/postLogout';
+import { postLogout } from 'src/api/postLogout';
 import { URL } from 'src/api/URL';
+import Modal from '..';
+import { MiddlePart } from './style';
 
 function LogoutModal({ controller: { hide, show } }: { controller: ModalController }) {
   const history = useHistory();

--- a/client/src/components/Modal/UserEdit/index.tsx
+++ b/client/src/components/Modal/UserEdit/index.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { ModalController } from '@customTypes/modal';
-import Modal from '..';
+import { useDispatch } from 'react-redux';
+
+import { setSelectedUser } from '@redux/selectedUser/slice';
 import { useUserdata, useSelectedUser } from '@hooks/index';
+import { ModalController } from '@customTypes/modal';
+import Colors from '@styles/Colors';
+import { patchUserdata } from 'src/api/patchUserdata';
+import { uploadFileToStorage } from 'src/utils/uploadFile';
+import Modal from '..';
 import {
   UserImageWrapper,
   UserGridWrapper,
@@ -10,11 +16,6 @@ import {
   ErrorDiv,
   InputImage,
 } from './style';
-import Colors from '@styles/Colors';
-import { uploadFileToStorage } from 'src/utils/uploadFile';
-import { patchUserdata } from 'src/api/patchUserdata';
-import { useDispatch } from 'react-redux';
-import { setSelectedUser } from '@redux/selectedUser/slice';
 
 export default function UserEditModal({ controller }: { controller: ModalController }) {
   const { userdata, mutate: mutateUserdata } = useUserdata();

--- a/client/src/components/Modal/UserInformation/index.tsx
+++ b/client/src/components/Modal/UserInformation/index.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
-import { ModalController } from '@customTypes/modal';
-import Modal from '..';
-import { useSelectedUser, useOtherUserData } from '@hooks/index';
 import { useDispatch } from 'react-redux';
+
 import { setSelectedUser } from '@redux/selectedUser/slice';
-import { UserDot, UserImageWrapper, UserImage, UserGridWrapper, UserName, UserBio } from './style';
+import { useSelectedUser, useOtherUserData } from '@hooks/index';
+import { ModalController } from '@customTypes/modal';
 import Colors from '@styles/Colors';
+import Modal from '..';
+import { UserDot, UserImageWrapper, UserImage, UserGridWrapper, UserName, UserBio } from './style';
 
 export default function UserInformationModal({ controller }: { controller: ModalController }) {
   const selectedUser = useSelectedUser();

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ModalController, ModalData } from '@customTypes/modal';
-import { ModalCloseIcon } from '../common/Icons';
+import { ModalCloseIcon } from '@components/common/Icons';
 import {
   BottomRightButton,
   Bottom,

--- a/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
+++ b/client/src/components/SideBar/Channels/ChannelListItem/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
+
+import { setSelectedChannel } from '@redux/selectedChannel/slice';
 import { useSelectedGroup, useSelectedChannel } from '@hooks/index';
 import { URL } from 'src/api/URL';
-import { setSelectedChannel } from '../../../../redux/selectedChannel/slice';
-import { ChannelChattingIcon, ChannelMeetingIcon, GroupDeleteIcon } from '../../../common/Icons';
+import { ChannelChattingIcon, ChannelMeetingIcon, GroupDeleteIcon } from '@components/common/Icons';
 import { ListItem } from './style';
 
 interface Props {

--- a/client/src/components/SideBar/Channels/index.tsx
+++ b/client/src/components/SideBar/Channels/index.tsx
@@ -1,14 +1,15 @@
 import React, { useState, useEffect } from 'react';
+
 import { useSelectedGroup } from '@hooks/index';
 import MeetEvent from '@customTypes/socket/MeetEvent';
-import { socket } from '../../../utils/socket';
-import { ChannelAddIcon, ChannelOpenIcon } from '../../common/Icons';
-import { getURLParams } from '../../../utils/getURLParams';
+import { ModalController } from '@customTypes/modal';
+import { socket } from 'src/utils/socket';
+import { getURLParams } from 'src/utils/getURLParams';
 import ChannelListItem from './ChannelListItem';
 import MeetingUserList from './MeetingUserList';
-import { ChannelWrapper, ChannelType } from './style';
 import ChannelCreateModal from '@components/Modal/ChannelCreate';
-import { ModalController } from '@customTypes/modal';
+import { ChannelAddIcon, ChannelOpenIcon } from '@components/common/Icons';
+import { ChannelWrapper, ChannelType } from './style';
 
 interface Props {
   channelType: 'chatting' | 'meeting';

--- a/client/src/components/SideBar/GroupNav/index.tsx
+++ b/client/src/components/SideBar/GroupNav/index.tsx
@@ -1,12 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
-import { useGroups, useSelectedGroup } from '@hooks/index';
+import { mutate } from 'swr';
+
 import { setSelectedChannel } from '@redux/selectedChannel/slice';
 import { setSelectedGroup } from '@redux/selectedGroup/slice';
 import { setSelectedChat } from '@redux/selectedChat/slice';
-import GroupJoinModal from '../../Modal/GroupJoin';
-import { socket } from '../../../utils/socket';
+import {
+  addUserConnection,
+  removeUserConnection,
+  setGroupConnection,
+} from '@redux/groupConnection/slice';
+import { useGroups, useSelectedGroup } from '@hooks/index';
+import { ModalController } from '@customTypes/modal';
+import GroupEvent from '@customTypes/socket/GroupEvent';
+import { API_URL } from 'src/api/API_URL';
+import { URL } from 'src/api/URL';
+import { socket } from 'src/utils/socket';
+import GroupCreateModal from '@components/Modal/GroupCreate';
+import GroupAddModal from '@components/Modal/GroupAdd';
+import GroupJoinModal from '@components/Modal/GroupJoin';
+import { GroupAddIcon } from '@components/common/Icons';
 import {
   GroupListWrapper,
   GroupList,
@@ -15,19 +29,6 @@ import {
   GroupListDivider,
   AddGroupButton,
 } from './style';
-import { ModalController } from '@customTypes/modal';
-import {
-  addUserConnection,
-  removeUserConnection,
-  setGroupConnection,
-} from '@redux/groupConnection/slice';
-import GroupCreateModal from '../../Modal/GroupCreate';
-import GroupAddModal from '../../Modal/GroupAdd';
-import { mutate } from 'swr';
-import { API_URL } from '../../../api/API_URL';
-import GroupEvent from '@customTypes/socket/GroupEvent';
-import { GroupAddIcon } from '../../common/Icons';
-import { URL } from 'src/api/URL';
 
 function GroupNav() {
   const { groups, mutate: mutateGroups } = useGroups();

--- a/client/src/components/SideBar/GroupSetting/index.tsx
+++ b/client/src/components/SideBar/GroupSetting/index.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
+
 import { useUserdata, useSelectedGroup } from '@hooks/index';
 import { ModalController } from '@customTypes/modal';
-import { GroupDeleteIcon, GroupInviteIcon } from '../../common/Icons';
-import GroupInviteModal from '../../Modal/GroupInvite';
-import GroupDeleteModal from '../../Modal/GroupDelete';
+import { GroupDeleteIcon, GroupInviteIcon } from '@components/common/Icons';
+import GroupInviteModal from '@components/Modal/GroupInvite';
+import GroupDeleteModal from '@components/Modal/GroupDelete';
 import { GroupSettingWrapper } from './style';
 
 function GroupSetting() {

--- a/client/src/components/SideBar/Profile/index.tsx
+++ b/client/src/components/SideBar/Profile/index.tsx
@@ -1,8 +1,13 @@
 import React, { useState } from 'react';
-import { DeviceControl, ProfileWrapper } from './style';
 import { useDispatch } from 'react-redux';
+
+import { setUserDevice } from '@redux/userDevice/slice';
+import { setSelectedUser } from '@redux/selectedUser/slice';
 import { useSelectedChannel, useUserdata, useUserDevice, useSelectedUser } from '@hooks/index';
-import { setUserDevice } from '../../../redux/userDevice/slice';
+import MeetEvent from '@customTypes/socket/MeetEvent';
+import { socket } from 'src/utils/socket';
+import UserInformationModal from '@components/Modal/UserInformation';
+import UserEditModal from '@components/Modal/UserEdit';
 import {
   CameraOffIcon,
   CameraOnIcon,
@@ -10,12 +15,8 @@ import {
   MicOnIcon,
   SpeakerOffIcon,
   SpeakerOnIcon,
-} from '../../common/Icons';
-import { socket } from 'src/utils/socket';
-import MeetEvent from '@customTypes/socket/MeetEvent';
-import { setSelectedUser } from '@redux/selectedUser/slice';
-import UserInformationModal from '@components/Modal/UserInformation';
-import UserEditModal from '@components/Modal/UserEdit';
+} from '@components/common/Icons';
+import { DeviceControl, ProfileWrapper } from './style';
 
 function Profile() {
   const dispatch = useDispatch();

--- a/client/src/components/SideBar/index.tsx
+++ b/client/src/components/SideBar/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { useSelectedGroup } from '../../hooks';
+
+import { useSelectedGroup } from '@hooks/index';
 import Channels from './Channels';
 import GroupNav from './GroupNav';
 import GroupSetting from './GroupSetting';

--- a/client/src/components/common/Background/index.tsx
+++ b/client/src/components/common/Background/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Layout from './style';
 
 interface Props {

--- a/client/src/components/common/Empty/index.tsx
+++ b/client/src/components/common/Empty/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+
 import EmptyWrapper from './style';
 
 function Empty() {
   return (
     <EmptyWrapper>
       <div>
-        <img src="/images/default_profile.png" />
+        <img src="/images/default_profile.png" alt="select channel" />
         <p>채널을 선택해주세요!</p>
       </div>
     </EmptyWrapper>

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -1,14 +1,15 @@
 import React, { useLayoutEffect } from 'react';
 import { useDispatch } from 'react-redux';
+
+import { setSelectedChannel } from '@redux/selectedChannel/slice';
+import { setSelectedGroup } from '@redux/selectedGroup/slice';
+import { useGroups, useSelectedChannel, useSelectedGroup } from '@hooks/index';
+import { getURLParams } from 'src/utils/getURLParams';
 import ChannelHeader from '@components/ChannelHeader';
 import Chat from '@components/Chat';
 import Meet from '@components/Meet';
 import SideBar from '@components/SideBar';
 import Empty from '@components/common/Empty';
-import { useGroups, useSelectedChannel, useSelectedGroup } from '@hooks/index';
-import { setSelectedChannel } from '@redux/selectedChannel/slice';
-import { setSelectedGroup } from '@redux/selectedGroup/slice';
-import { getURLParams } from '../../utils/getURLParams';
 import { Layout, MainWrapper } from './style';
 
 function Main() {

--- a/client/src/pages/SignIn/index.tsx
+++ b/client/src/pages/SignIn/index.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
-import Background from '@components/common/Background';
 import { Link, useHistory } from 'react-router-dom';
+
+import { STATUS_CODES } from 'src/api/STATUS_CODES';
+import { URL } from 'src/api/URL';
+import { SIGN_IN_ERROR_MESSAGE } from 'src/utils/message';
+import { checkLogin } from 'src/utils/checkResponse';
+import { tryLogin } from 'src/utils/api';
+import Background from '@components/common/Background';
 import {
   SignInWrapper,
   LogoWrapper,
@@ -11,11 +17,6 @@ import {
   LoginButton,
   ErrorResponse,
 } from './style';
-import { SIGN_IN_ERROR_MESSAGE } from '../../utils/message';
-import { checkLogin } from '../../utils/checkResponse';
-import { tryLogin } from '../../utils/api';
-import { STATUS_CODES } from '../../api/STATUS_CODES';
-import { URL } from 'src/api/URL';
 
 const { ID_EMPTY_ERROR, PASSWORD_EMPTY_ERROR } = SIGN_IN_ERROR_MESSAGE;
 

--- a/client/src/pages/SignUp/index.tsx
+++ b/client/src/pages/SignUp/index.tsx
@@ -8,7 +8,9 @@ import {
   validatePassword,
   validateForm,
   isSendPossible,
-} from '../../utils/checkResponse';
+} from 'src/utils/checkResponse';
+import { SIGN_UP_ERROR_MESSAGE } from 'src/utils/message';
+import { trySignUp } from 'src/utils/api';
 import {
   SignUpWrapper,
   Title,
@@ -17,8 +19,6 @@ import {
   SignUpButton,
   ButtonWrapper,
 } from './style';
-import { SIGN_UP_ERROR_MESSAGE } from '../../utils/message';
-import { trySignUp } from '../../utils/api';
 
 const { ID_FORM_ERROR, PASSWORD_FORM_ERROR, USERNAME_ERROR, EMPTY_INPUT_ERROR } =
   SIGN_UP_ERROR_MESSAGE;


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #276 
## What did you do?

<!--무엇을 하셨나요?-->
- [x] import 시 alias가 제대로 먹지 않은 부분 수정
- [x] import 시 순서 적용 (뒤에 자세히 나와있음)


## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
일단 아래 순서대로 했는데 다른게 더 좋다면 언제든지 말씀해주세요~
```
 리액트
 리덕스
 리액트 라우터 돔

 @리덕스
 @훅
 @커스텀타입스
 API (src로 시작)
 유틸함수 (src로 시작)
 컴포넌트 (몇개는 @components로 시작, 몇개는 상대경로)
 아이콘 (@components/common/Icons으로 시작)
 스타일 컴포넌트 ("./style")
```

