### PR TITLE
[Feat/#279] 채팅을 날짜별로 묶어서 보여주는 기능 구현

### DIFF
--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -121,7 +121,7 @@ function Chat() {
       <ChatContainer>
         <Chats ref={chatListRef}>
           {Object.entries(makeChatSection(chats)).map(([day, dayChats]) => (
-            <Section>
+            <Section key={day}>
               <StickyWrapper>
                 <button>{day}</button>
               </StickyWrapper>

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -115,7 +115,7 @@ function Chat() {
       socket.off(ThreadEvent.thread);
     };
   }, [onChat, onLike, onThread]);
-  console.log(makeChatSection(chats));
+
   return (
     <ChatPart>
       <ChatContainer>

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -13,7 +13,8 @@ import ChatInput from './ChatInput';
 import ChatItem from './ChatItem';
 import UserConnection from './UserConnection';
 import Thread from './Thread';
-import { ChatContainer, Chats, ChatPart, ChatInputWrapper } from './style';
+import { ChatContainer, Chats, ChatPart, ChatInputWrapper, StickyWrapper, Section } from './style';
+import { makeChatSection } from 'src/utils/makeChatSection';
 
 const PAGE_SIZE = 20;
 const THRESHOLD = 300;
@@ -114,17 +115,21 @@ function Chat() {
       socket.off(ThreadEvent.thread);
     };
   }, [onChat, onLike, onThread]);
-
+  console.log(makeChatSection(chats));
   return (
     <ChatPart>
       <ChatContainer>
         <Chats ref={chatListRef}>
-          {chats
-            ?.flat()
-            .reverse()
-            .map((chat) => (
-              <ChatItem key={chat.id} chatData={chat} />
-            ))}
+          {Object.entries(makeChatSection(chats)).map(([day, dayChats]) => (
+            <Section>
+              <StickyWrapper>
+                <button>{day}</button>
+              </StickyWrapper>
+              {dayChats.map((chat: ChatData) => (
+                <ChatItem key={chat.id} chatData={chat} />
+              ))}
+            </Section>
+          ))}
         </Chats>
         <ChatInputWrapper>
           <ChatInput scrollToBottom={scrollToBottom} />

--- a/client/src/components/Chat/style.ts
+++ b/client/src/components/Chat/style.ts
@@ -1,6 +1,30 @@
 import styled from 'styled-components';
 import Colors from '../../styles/Colors';
 
+const Section = styled.div`
+  width: 100%;
+`;
+
+const StickyWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  flex: 1;
+  width: 100%;
+  position: sticky;
+  top: 5px;
+  z-index: 2;
+  & > button {
+    font-weight: bold;
+    font-size: 13px;
+    height: 28px;
+    z-index: 10;
+    line-height: 27px;
+    padding: 0 16px;
+    border-radius: 24px;
+    background-color: ${Colors.White};
+    border: 1.5px solid ${Colors.Gray2};
+  }
+`;
 const ChatPart = styled.div`
   display: flex;
   width: 100%;
@@ -38,4 +62,4 @@ const ChatInputWrapper = styled.div`
   width: 100%;
 `;
 
-export { ChatContainer, Chats, ChatPart, ChatInputWrapper };
+export { ChatContainer, Chats, ChatPart, ChatInputWrapper, StickyWrapper, Section };

--- a/client/src/utils/makeChatSection.ts
+++ b/client/src/utils/makeChatSection.ts
@@ -1,13 +1,16 @@
 const makeChatSection = (chats: any[] | undefined) => {
   const chatSection: { [key: string]: any } = {};
-  chats?.flat()?.forEach((chat) => {
-    const day = getDay(chat['createdAt']);
-    if (chatSection[day]) {
-      chatSection[day].push(chat);
-    } else {
-      chatSection[day] = [chat];
-    }
-  });
+  chats
+    ?.flat()
+    .reverse()
+    ?.forEach((chat) => {
+      const day = getDay(chat['createdAt']);
+      if (chatSection[day]) {
+        chatSection[day].push(chat);
+      } else {
+        chatSection[day] = [chat];
+      }
+    });
   return chatSection;
 };
 

--- a/client/src/utils/makeChatSection.ts
+++ b/client/src/utils/makeChatSection.ts
@@ -1,0 +1,12 @@
+const makeChatSection = (chats: any[] | undefined) => {};
+
+const getDay = (targetDay: string) => {
+  const date = new Date(targetDay);
+  const month = ('0' + (1 + date.getMonth())).slice(-2);
+  const day = ('0' + date.getDate()).slice(-2);
+
+  const WEEKDAY = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
+  return `${month}월 ${day}일 ${WEEKDAY[date.getDay()]}`;
+};
+
+export { makeChatSection };

--- a/client/src/utils/makeChatSection.ts
+++ b/client/src/utils/makeChatSection.ts
@@ -19,8 +19,8 @@ const getDay = (targetDay: string) => {
   const month = ('0' + (1 + date.getMonth())).slice(-2);
   const day = ('0' + date.getDate()).slice(-2);
 
-  const WEEKDAY = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
-  return `${month}월 ${day}일 ${WEEKDAY[date.getDay()]}`;
+  const WEEKDAY = ['일', '월', '화', '수', '목', '금', '토'];
+  return `${month}월 ${day}일 ${WEEKDAY[date.getDay()]}요일`;
 };
 
 export { makeChatSection };

--- a/client/src/utils/makeChatSection.ts
+++ b/client/src/utils/makeChatSection.ts
@@ -1,4 +1,15 @@
-const makeChatSection = (chats: any[] | undefined) => {};
+const makeChatSection = (chats: any[] | undefined) => {
+  const chatSection: { [key: string]: any } = {};
+  chats?.flat()?.forEach((chat) => {
+    const day = getDay(chat['createdAt']);
+    if (chatSection[day]) {
+      chatSection[day].push(chat);
+    } else {
+      chatSection[day] = [chat];
+    }
+  });
+  return chatSection;
+};
 
 const getDay = (targetDay: string) => {
   const date = new Date(targetDay);


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #279 
## What did you do?
![image](https://user-images.githubusercontent.com/52554235/142802232-059cf253-9d1f-4017-bd18-2465246df25a.png)

<!--무엇을 하셨나요?-->
- [x]  채팅을 날짜별로 묶어서 보여주는 기능 구현

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
현재 chatList를 받으면 그것의 날짜의 키와 그 날의 chat 배열을 value로 가집니다. 
![image](https://user-images.githubusercontent.com/52554235/142802577-7ab7b3e0-9463-4da9-bf81-208424f35845.png)

그리고 이러한 객체를 `Object.entries`를 이용해서 화면에 그립니다.


