### PR TITLE
style: 화상 채팅에서 내가 보낸 채팅은 오른쪽 정렬하도록 스타일 변경

### DIFF
--- a/client/src/components/Meet/MeetChat/index.tsx
+++ b/client/src/components/Meet/MeetChat/index.tsx
@@ -79,7 +79,7 @@ function MeetChat() {
       </CloseChatButton>
       <ChatList ref={chatListRef}>
         {chats.map(({ id, loginID, username, thumbnail, message, createdAt }) => (
-          <Chat key={id}>
+          <Chat key={id} isSender={loginID === userdata.loginID}>
             <div>
               <img src={thumbnail ?? '/images/default_profile.png'} alt="user profile" />
               <ChatHeader>

--- a/client/src/components/Meet/MeetChat/style.ts
+++ b/client/src/components/Meet/MeetChat/style.ts
@@ -18,17 +18,12 @@ const ChatList = styled.ul`
   height: calc(100% - 52px);
 
   &::-webkit-scrollbar {
-    display: none;
+    width: 5px;
   }
 
   &::-webkit-scrollbar-thumb {
     background: ${Colors.Gray2};
     border-radius: 10px;
-  }
-
-  &:hover::-webkit-scrollbar {
-    display: block;
-    width: 10px;
   }
 `;
 
@@ -38,7 +33,7 @@ const ChatHeader = styled.div`
   & div:first-child {
     font-weight: bold;
     font-size: 15px;
-    margin-right: 3px;
+    margin: 0 3px;
   }
   & div:last-child {
     color: ${Colors.Gray1};
@@ -46,27 +41,36 @@ const ChatHeader = styled.div`
   }
 `;
 
-const Chat = styled.li`
+interface IChat {
+  isSender: boolean;
+}
+
+const Chat = styled.li<IChat>`
   margin-top: 5px;
+  ${(props) => props.isSender && `text-align: right;`}
   & div {
     display: flex;
+    ${(props) => props.isSender && `flex-direction: row-reverse;`}
     & img {
       width: 40px;
       height: 40px;
       border-radius: 50%;
       background-color: ${Colors.Gray2};
-      margin-right: 5px;
+      ${(props) => (props.isSender ? `margin-right: 3px;` : `margin-left: 3px;`)}
     }
+  }
+  & span {
+    ${(props) => (props.isSender ? `margin-right: 30px;` : `margin-left: 30px;`)}
   }
 `;
 
 const Message = styled.span`
   display: inline-block;
-  margin-left: 30px;
   padding: 12px;
   background-color: ${Colors.Gray3};
   border-radius: 15px;
   overflow-wrap: break-word;
+  word-break: break-all;
 `;
 
 const ShowChatButton = styled.button`


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #284 
- 
## What did you do?
<!--무엇을 하셨나요?-->
- [x]  화상 채팅에서 내가 보낸 채팅은 오른쪽 정렬하도록 스타일 변경
- [x]  스크롤 항상 보이도록 수정

![image](https://user-images.githubusercontent.com/73640737/142812063-1c4d70a2-0daa-449b-aba9-4c0ee94420fb.png)

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->

## 레퍼런스
<!--참고한 자료가 있나요?-->

