### PR TITLE
fix: 쓰레드에 이미지가 출력되도록 수정, 채팅 글씨 크기 조정 및 초단위 표시 제거

### DIFF
--- a/client/src/components/Chat/ChatItem/index.tsx
+++ b/client/src/components/Chat/ChatItem/index.tsx
@@ -66,7 +66,7 @@ function ChatItem({ chatData }: { chatData: ChatData }) {
       <div>
         <ChatHeader>
           <div>{user.username}</div>
-          <div>{new Date(createdAt).toLocaleTimeString('ko-KR')}</div>
+          <div>{new Date(createdAt).toLocaleTimeString('ko-KR').slice(0, -3)}</div>
         </ChatHeader>
         <ChatContent>{content}</ChatContent>
         <FileWrapper>

--- a/client/src/components/Chat/ChatItem/style.ts
+++ b/client/src/components/Chat/ChatItem/style.ts
@@ -33,14 +33,19 @@ const FileWrapper = styled.div`
 
 const ChatHeader = styled.div`
   display: flex;
+  align-items: center;
   gap: 12px;
   color: ${Colors.Gray1};
   margin-bottom: 8px;
 
   & > div:first-child {
     font-weight: 600;
-    font-size: 15px;
+    font-size: 16px;
     color: ${Colors.Black};
+  }
+  & > div:last-child {
+    font-size: 13px;
+    line-height: 16px;
   }
 `;
 

--- a/client/src/components/Chat/Thread/index.tsx
+++ b/client/src/components/Chat/Thread/index.tsx
@@ -17,6 +17,7 @@ import {
   Input,
   InputWrapper,
   Wrapper,
+  FileWrapper,
   ThreadWrapper,
   ThreadHeaderWrapper,
   OriginalChatWrapper,
@@ -32,6 +33,7 @@ function Thread({ selectedChat }: { selectedChat: ChatData }) {
     createdAt,
     content,
     user: { username, thumbnail },
+    files,
   } = selectedChat;
   const threadChatListRef = useRef<HTMLDivElement>(null);
 
@@ -93,6 +95,14 @@ function Thread({ selectedChat }: { selectedChat: ChatData }) {
               <p>{new Date(createdAt).toLocaleTimeString('ko-KR')}</p>
             </div>
             <div>{content}</div>
+            <FileWrapper>
+              {files &&
+                files.map((file) => (
+                  <div key={file.src}>
+                    <img src={file.src} />
+                  </div>
+                ))}
+            </FileWrapper>
           </div>
         </OriginalChatWrapper>
         <ChatLengthWrapper>{data?.length}개의 댓글</ChatLengthWrapper>

--- a/client/src/components/Chat/Thread/index.tsx
+++ b/client/src/components/Chat/Thread/index.tsx
@@ -92,7 +92,7 @@ function Thread({ selectedChat }: { selectedChat: ChatData }) {
           <div>
             <div>
               <p>{username}</p>
-              <p>{new Date(createdAt).toLocaleTimeString('ko-KR')}</p>
+              <p>{new Date(createdAt).toLocaleTimeString('ko-KR').slice(0, -3)}</p>
             </div>
             <div>{content}</div>
             <FileWrapper>

--- a/client/src/components/Chat/Thread/index.tsx
+++ b/client/src/components/Chat/Thread/index.tsx
@@ -23,6 +23,7 @@ import {
   OriginalChatWrapper,
   ThreadChatWrapper,
   ChatLengthWrapper,
+  ChatLength,
 } from './style';
 
 function Thread({ selectedChat }: { selectedChat: ChatData }) {
@@ -105,7 +106,11 @@ function Thread({ selectedChat }: { selectedChat: ChatData }) {
             </FileWrapper>
           </div>
         </OriginalChatWrapper>
-        <ChatLengthWrapper>{data?.length}개의 댓글</ChatLengthWrapper>
+        <ChatLengthWrapper>
+          <ChatLength>
+            <p>{data?.length}</p>개의 댓글
+          </ChatLength>
+        </ChatLengthWrapper>
         <ThreadChatWrapper ref={threadChatListRef}>
           {data && data.map((v: ChatData) => <ThreadItem key={v.id} threadData={v} />)}
         </ThreadChatWrapper>

--- a/client/src/components/Chat/Thread/style.ts
+++ b/client/src/components/Chat/Thread/style.ts
@@ -110,10 +110,34 @@ const Input = styled.input`
   box-sizing: border-box;
 `;
 
+const FileWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  max-height: 200px;
+  overflow-y: scroll;
+  margin-top: 10px;
+  &::-webkit-scrollbar {
+    width: 5px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: ${Colors.Gray2};
+    border-radius: 10px;
+  }
+  & div {
+    margin-top: 10px;
+  }
+  & img {
+    max-width: 200px;
+    height: 120px;
+    object-fit: cover;
+  }
+`;
+
 export {
   InputWrapper,
   Input,
   Wrapper,
+  FileWrapper,
   ThreadWrapper,
   ThreadHeaderWrapper,
   OriginalChatWrapper,

--- a/client/src/components/Chat/Thread/style.ts
+++ b/client/src/components/Chat/Thread/style.ts
@@ -37,6 +37,10 @@ const ThreadHeaderWrapper = styled.div`
       font-size: 20px;
       font-weight: 700;
     }
+    & > div:last-child {
+      margin-left: 5px;
+      color: ${Colors.Gray1};
+    }
   }
 `;
 
@@ -91,11 +95,18 @@ const OriginalChatWrapper = styled.div`
   }
 `;
 
-const ChatLengthWrapper = styled.p`
+const ChatLengthWrapper = styled.div``;
+
+const ChatLength = styled.p`
   margin-top: -9.5px;
   background-color: ${Colors.White};
   padding: 0 12px;
   display: table;
+  color: ${Colors.Gray1};
+  & p {
+    display: inline-block;
+    margin-right: 1px;
+  }
 `;
 
 const InputWrapper = styled.form`
@@ -146,4 +157,5 @@ export {
   OriginalChatWrapper,
   ThreadChatWrapper,
   ChatLengthWrapper,
+  ChatLength,
 };

--- a/client/src/components/Chat/Thread/style.ts
+++ b/client/src/components/Chat/Thread/style.ts
@@ -77,12 +77,16 @@ const OriginalChatWrapper = styled.div`
   & > div > div {
     display: flex;
     align-items: center;
+    margin: 5px 0;
     & > p:first-child {
+      font-size: 16px;
       font-weight: 700;
       margin-right: 5px;
     }
-    & > p:not(:first-child) {
+    & > p:last-child {
       font-size: 13px;
+      line-height: 16px;
+      color: ${Colors.Gray1};
     }
   }
 `;
@@ -115,7 +119,6 @@ const FileWrapper = styled.div`
   flex-wrap: wrap;
   max-height: 200px;
   overflow-y: scroll;
-  margin-top: 10px;
   &::-webkit-scrollbar {
     width: 5px;
   }

--- a/client/src/components/Chat/ThreadItem/index.tsx
+++ b/client/src/components/Chat/ThreadItem/index.tsx
@@ -16,7 +16,7 @@ function ThreadItem({ threadData }: { threadData: ThreadData }) {
       <div>
         <div>
           <h2>{username}</h2>
-          <p>{new Date(createdAt).toLocaleTimeString('ko-KR')}</p>
+          <p>{new Date(createdAt).toLocaleTimeString('ko-KR').slice(0, -3)}</p>
         </div>
         <div>{content}</div>
       </div>

--- a/client/src/components/Chat/ThreadItem/style.ts
+++ b/client/src/components/Chat/ThreadItem/style.ts
@@ -24,10 +24,13 @@ const Wrapper = styled.div`
     word-break: break-all;
   }
   & h2 {
+    font-size: 16px;
     font-weight: 700;
   }
   & p {
     color: ${Colors.Gray1};
+    font-size: 13px;
+    line-height: 16px;
   }
 `;
 

--- a/client/src/components/Chat/ThreadPreview/index.tsx
+++ b/client/src/components/Chat/ThreadPreview/index.tsx
@@ -18,7 +18,7 @@ function ThreadPreview({
     <ThreadPreviewWrapper onClick={selectChat}>
       <img src={thumbnail ? thumbnail : '/images/default_profile.png'} alt="thumbnail" />
       <p>{count}개의 댓글</p>
-      <p>({new Date(threadLastTime).toLocaleTimeString('ko-KR')})</p>
+      <p>({new Date(threadLastTime).toLocaleTimeString('ko-KR').slice(0, -3)})</p>
     </ThreadPreviewWrapper>
   );
 }

--- a/client/src/components/Chat/ThreadPreview/style.ts
+++ b/client/src/components/Chat/ThreadPreview/style.ts
@@ -14,12 +14,14 @@ const ThreadPreviewWrapper = styled.div`
     background-color: ${Colors.Gray1};
   }
   & > p:nth-child(2) {
-    font-size: 15px;
+    font-size: 13px;
     font-weight: 600;
+    line-height: 18px;
     margin-right: 5px;
   }
   & > p:nth-child(3) {
     font-size: 12px;
+    line-height: 18px;
     color: ${Colors.Gray7};
   }
 `;


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #293 

## What did you do?

<!--무엇을 하셨나요?-->
- [x] 쓰레드에 이미지 출력
- [x] 채팅, 쓰레드 글씨 크기 변경
- [x] 채팅 입력 시간 초단위 표시 제거

![image](https://user-images.githubusercontent.com/73640737/142844459-d4f58abf-dc54-4c26-a8e4-1c4f46ababa6.png)

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
쓰레드에 이미지를 불러오게 만들었어요
너무 길면 쓰레드 댓글이 안보여서 최대 높이를 지정했어요
사진이 많으면 스크롤이 생겨요!

`new Date(Time).toLocaleTimeString('ko-KR').slice(0, -3)`
이부분이 계속 중복이라 리팩터링 할 때 util에 빼보도록 할게요~

## 레퍼런스
<!--참고한 자료가 있나요?-->

