### PR TITLE
Fix/오른쪽 사이드바 유저 목록과 쓰레드 너비 다르게 구현

### DIFF
--- a/client/src/components/Chat/ChatItem/style.ts
+++ b/client/src/components/Chat/ChatItem/style.ts
@@ -24,7 +24,7 @@ const FileWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   & div {
-    margin-top: 5px;
+    margin-top: 10px;
   }
   & img {
     max-width: 300px;
@@ -37,7 +37,6 @@ const FileWrapper = styled.div`
 const ChatHeader = styled.div`
   display: flex;
   align-items: center;
-  gap: 12px;
   color: ${Colors.Gray1};
   margin-bottom: 8px;
 
@@ -45,6 +44,7 @@ const ChatHeader = styled.div`
     font-weight: 600;
     font-size: 16px;
     color: ${Colors.Black};
+    margin-right: 5px;
   }
   & > div:last-child {
     font-size: 13px;

--- a/client/src/components/Chat/Thread/style.ts
+++ b/client/src/components/Chat/Thread/style.ts
@@ -3,7 +3,7 @@ import Colors from '../../../styles/Colors';
 
 const Wrapper = styled.div`
   background-color: ${Colors.White};
-  width: 300px;
+  width: 30%;
   height: calc(100vh - 50px);
   border-left: 1px solid ${Colors.Gray4};
   display: flex;

--- a/client/src/components/Chat/ThreadPreview/style.ts
+++ b/client/src/components/Chat/ThreadPreview/style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import Colors from '../../../styles/Colors';
 
 const ThreadPreviewWrapper = styled.div`
-  margin-top: 5px;
+  margin-top: 10px;
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -118,7 +118,7 @@ function Chat() {
 
   return (
     <ChatPart>
-      <ChatContainer>
+      <ChatContainer isSelectedChat={!!selectedChat}>
         <Chats ref={chatListRef}>
           {Object.entries(makeChatSection(chats)).map(([day, dayChats]) => (
             <Section key={day}>

--- a/client/src/components/Chat/style.ts
+++ b/client/src/components/Chat/style.ts
@@ -31,8 +31,12 @@ const ChatPart = styled.div`
   justify-content: space-between;
 `;
 
-const ChatContainer = styled.div`
-  width: calc(100% - 300px);
+interface IChatContainer {
+  isSelectedChat: boolean;
+}
+
+const ChatContainer = styled.div<IChatContainer>`
+  ${(props) => (props.isSelectedChat ? `width: 70%;` : `width: calc(100% - 300px);`)}
   height: calc(100vh - 50px);
   display: flex;
   flex-direction: column;

--- a/client/src/components/SideBar/Channels/MeetingUserList/style.ts
+++ b/client/src/components/SideBar/Channels/MeetingUserList/style.ts
@@ -30,6 +30,7 @@ const MeetingUserProfile = styled.img`
   width: 30px;
   height: 30px;
   border-radius: 50%;
+  object-fit: cover;
 `;
 
 export { MeetingUserListWrapper, MeetingUserProfileWrapper, MeetingUserProfile };


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->

## What did you do?

<!--무엇을 하셨나요?-->
- [x]  오른쪽 사이드바 유저 목록과 쓰레드 너비 다르게 구현

쓰레드 너비가 너무 작다는 의견이 있어서
쓰레드는 기존처럼 30%로, 유저 목록은 300px로 너비를 지정했습니다

![image](https://user-images.githubusercontent.com/73640737/142868909-02a66462-ba7d-42f4-aa7d-fe29db191b0b.png)

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->

## 레퍼런스
<!--참고한 자료가 있나요?-->

