### PR TITLE
Feat : 화상 회의 채널에서 비디오 클릭시 크게 보기

### DIFF
--- a/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
@@ -21,7 +21,7 @@ function FocusedVideo({
   return (
     <VideoWrapper onClick={onClick}>
       <Video autoPlay playsInline ref={videoRef} />
-      <UserInfo>{`${username}(${loginID})${isScreen && ' 님의 화면'}`}</UserInfo>
+      <UserInfo>{`${username}(${loginID})${isScreen ? ' 님의 화면' : ''}`}</UserInfo>
       {isScreen || (
         <>
           <DeviceStatus>

--- a/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useRef } from 'react';
+import { SelectedVideo } from '..';
+import { Video, VideoWrapper } from './style';
+
+function FocusedVideo({
+  selectedVideo,
+  onClick,
+}: {
+  selectedVideo: SelectedVideo;
+  onClick: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (videoRef.current && selectedVideo.stream) videoRef.current.srcObject = selectedVideo.stream;
+  }, [selectedVideo]);
+
+  return (
+    <VideoWrapper onClick={onClick}>
+      <Video autoPlay playsInline ref={videoRef}>
+        <p>{selectedVideo?.username}</p>
+      </Video>
+    </VideoWrapper>
+  );
+}
+
+export default FocusedVideo;

--- a/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useRef } from 'react';
+
+import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
 import { SelectedVideo } from '..';
-import { Video, VideoWrapper } from './style';
+import { ThumbnailWrapper, Thumbnail } from '../style';
+import { UserInfo, Video, VideoWrapper, DeviceStatus } from './style';
 
 function FocusedVideo({
-  selectedVideo,
+  selectedVideo: { loginID, username, stream, thumbnail, mic, cam, speaker, isScreen },
   onClick,
 }: {
   selectedVideo: SelectedVideo;
@@ -12,14 +15,22 @@ function FocusedVideo({
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
-    if (videoRef.current && selectedVideo.stream) videoRef.current.srcObject = selectedVideo.stream;
-  }, [selectedVideo]);
+    if (videoRef.current && stream) videoRef.current.srcObject = stream;
+  }, [stream]);
 
   return (
     <VideoWrapper onClick={onClick}>
-      <Video autoPlay playsInline ref={videoRef}>
-        <p>{selectedVideo?.username}</p>
-      </Video>
+      <Video autoPlay playsInline ref={videoRef} />
+      <UserInfo>{`${username}(${loginID})${isScreen && ' 님의 화면'}`}</UserInfo>
+      <DeviceStatus>
+        {mic || <MicOffIcon />}
+        {speaker || <SpeakerOffIcon />}
+      </DeviceStatus>
+      <ThumbnailWrapper>
+        {cam || (
+          <Thumbnail src={thumbnail || '/images/default_profile.png'} alt="profile"></Thumbnail>
+        )}
+      </ThumbnailWrapper>
     </VideoWrapper>
   );
 }

--- a/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
@@ -22,15 +22,19 @@ function FocusedVideo({
     <VideoWrapper onClick={onClick}>
       <Video autoPlay playsInline ref={videoRef} />
       <UserInfo>{`${username}(${loginID})${isScreen && ' 님의 화면'}`}</UserInfo>
-      <DeviceStatus>
-        {mic || <MicOffIcon />}
-        {speaker || <SpeakerOffIcon />}
-      </DeviceStatus>
-      <ThumbnailWrapper>
-        {cam || (
-          <Thumbnail src={thumbnail || '/images/default_profile.png'} alt="profile"></Thumbnail>
-        )}
-      </ThumbnailWrapper>
+      {isScreen || (
+        <>
+          <DeviceStatus>
+            {mic || <MicOffIcon />}
+            {speaker || <SpeakerOffIcon />}
+          </DeviceStatus>
+          <ThumbnailWrapper>
+            {cam || (
+              <Thumbnail src={thumbnail || '/images/default_profile.png'} alt="profile"></Thumbnail>
+            )}
+          </ThumbnailWrapper>
+        </>
+      )}
     </VideoWrapper>
   );
 }

--- a/client/src/components/Meet/MeetVideo/FocusedVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/style.ts
@@ -1,6 +1,8 @@
+import Colors from '@styles/Colors';
 import styled from 'styled-components';
 
 const VideoWrapper = styled.div`
+  position: relative;
   display: flex;
   width: calc(100% - 300px);
   height: 100%;
@@ -9,9 +11,30 @@ const VideoWrapper = styled.div`
 const Video = styled.video`
   width: 100%;
   height: 100%;
-  border-radius: 20px;
   justify-self: center;
   align-self: center;
+  object-fit: contain;
 `;
 
-export { VideoWrapper, Video };
+const UserInfo = styled.p`
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  border-radius: 10px;
+  padding: 8px 10px;
+  color: ${Colors.White};
+  background-color: rgba(0, 0, 0, 0.3);
+`;
+
+const DeviceStatus = styled.div`
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  z-index: 10;
+
+  svg {
+    margin-right: 5px;
+  }
+`;
+
+export { VideoWrapper, Video, UserInfo, DeviceStatus };

--- a/client/src/components/Meet/MeetVideo/FocusedVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/style.ts
@@ -3,17 +3,21 @@ import styled from 'styled-components';
 
 const VideoWrapper = styled.div`
   position: relative;
-  display: flex;
   width: calc(100% - 300px);
-  height: 100%;
+  height: calc(100% - 160px);
+  margin: auto 0;
+  margin-left: 20px;
 `;
 
 const Video = styled.video`
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
-  justify-self: center;
-  align-self: center;
   object-fit: contain;
+  border-radius: 20px;
+  background-color: black;
 `;
 
 const UserInfo = styled.p`

--- a/client/src/components/Meet/MeetVideo/FocusedVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const VideoWrapper = styled.div`
+  display: flex;
+  width: calc(100% - 300px);
+  height: 100%;
+`;
+
+const Video = styled.video`
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
+  justify-self: center;
+  align-self: center;
+`;
+
+export { VideoWrapper, Video };

--- a/client/src/components/Meet/MeetVideo/MeetButton/style.ts
+++ b/client/src/components/Meet/MeetVideo/MeetButton/style.ts
@@ -2,6 +2,10 @@ import styled from 'styled-components';
 import Colors from '@styles/Colors';
 
 const MeetButtonWrapper = styled.div`
+  position: absolute;
+  left: auto;
+  right: auto;
+  bottom: 10px;
   width: 100%;
   height: 10%;
   display: flex;

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -1,17 +1,26 @@
 import React, { useRef, useEffect } from 'react';
 
-import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
+import { CameraOnIcon, MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
 import { IMeetingUser, SelectedVideo } from '..';
-import { VideoWrapper, Video, Thumbnail, DeviceStatus, ThumbnailWrapper } from '../style';
+import {
+  VideoWrapper,
+  Video,
+  Thumbnail,
+  DeviceStatus,
+  ThumbnailWrapper,
+  SelectVideoIndicator,
+} from '../style';
 
 function OtherVideo({
   member: { socketID, loginID, username, thumbnail, cam, speaker, mic, stream, screen, pc },
   muted,
   selectVideo,
+  selectedVideo,
 }: {
   member: IMeetingUser;
   muted: boolean;
-  selectVideo: (videoInfo: SelectedVideo) => (e: any) => void;
+  selectVideo: (videoInfo: SelectedVideo) => () => void;
+  selectedVideo: SelectedVideo | null;
 }) {
   const camRef = useRef<HTMLVideoElement>(null);
   const screenRef = useRef<HTMLVideoElement>(null);
@@ -73,6 +82,11 @@ function OtherVideo({
           {mic || <MicOffIcon />}
           {speaker || <SpeakerOffIcon />}
         </DeviceStatus>
+        {stream && selectedVideo?.stream?.id === stream?.id && (
+          <SelectVideoIndicator>
+            <CameraOnIcon />
+          </SelectVideoIndicator>
+        )}
       </VideoWrapper>
       {screen && (
         <VideoWrapper
@@ -84,6 +98,11 @@ function OtherVideo({
         >
           <Video key={socketID} muted={muted} autoPlay playsInline ref={screenRef} />
           <p>{`${username}(${loginID}) 님의 화면`}</p>
+          {screen && selectedVideo?.stream?.id === screen?.id && (
+            <SelectVideoIndicator>
+              <CameraOnIcon />
+            </SelectVideoIndicator>
+          )}
         </VideoWrapper>
       )}
     </>

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect } from 'react';
 
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
 import { IMeetingUser, SelectedVideo } from '..';
-import { VideoWrapper, Video, Thumbnail } from '../style';
+import { VideoWrapper, Video, Thumbnail, DeviceStatus, ThumbnailWrapper } from '../style';
 
 function OtherVideo({
   member: { socketID, loginID, username, thumbnail, cam, speaker, mic, stream, screen, pc },
@@ -55,40 +55,35 @@ function OtherVideo({
 
   return (
     <>
-      <VideoWrapper>
-        <Video
-          muted={muted}
-          autoPlay
-          playsInline
-          ref={camRef}
-          onClick={selectVideo({
-            ...videoInfo,
-            stream: stream,
-            isScreen: true,
-          })}
-        />
+      <VideoWrapper
+        onClick={selectVideo({
+          ...videoInfo,
+          stream: stream,
+          isScreen: true,
+        })}
+      >
+        <Video muted={muted} autoPlay playsInline ref={camRef} />
+        <ThumbnailWrapper>
+          {cam || (
+            <Thumbnail src={thumbnail || '/images/default_profile.png'} alt="profile"></Thumbnail>
+          )}
+        </ThumbnailWrapper>
         <p>{`${username}(${loginID})`}</p>
-        {mic || <MicOffIcon />}
-        {speaker || <SpeakerOffIcon />}
-        {cam || (
-          <Thumbnail src={thumbnail || '/images/default_profile.png'} alt="profile"></Thumbnail>
-        )}
+        <DeviceStatus>
+          {mic || <MicOffIcon />}
+          {speaker || <SpeakerOffIcon />}
+        </DeviceStatus>
       </VideoWrapper>
       {screen && (
-        <VideoWrapper>
-          <Video
-            key={socketID}
-            muted={muted}
-            autoPlay
-            playsInline
-            ref={screenRef}
-            onClick={selectVideo({
-              ...videoInfo,
-              stream: screen,
-              isScreen: true,
-            })}
-          />
-          <p>{`${username}(${loginID})님의 화면`}</p>
+        <VideoWrapper
+          onClick={selectVideo({
+            ...videoInfo,
+            stream: screen,
+            isScreen: true,
+          })}
+        >
+          <Video key={socketID} muted={muted} autoPlay playsInline ref={screenRef} />
+          <p>{`${username}(${loginID}) 님의 화면`}</p>
         </VideoWrapper>
       )}
     </>

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -63,6 +63,7 @@ function OtherVideo({
           ref={camRef}
           onClick={selectVideo({
             ...videoInfo,
+            stream: stream,
             isScreen: true,
           })}
         />
@@ -83,6 +84,7 @@ function OtherVideo({
             ref={screenRef}
             onClick={selectVideo({
               ...videoInfo,
+              stream: screen,
               isScreen: true,
             })}
           />

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -59,7 +59,7 @@ function OtherVideo({
         onClick={selectVideo({
           ...videoInfo,
           stream: stream,
-          isScreen: true,
+          isScreen: false,
         })}
       >
         <Video muted={muted} autoPlay playsInline ref={camRef} />

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -1,18 +1,30 @@
 import React, { useRef, useEffect } from 'react';
 
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import { IMeetingUser } from '..';
+import { IMeetingUser, SelectedVideo } from '..';
 import { VideoItemWrapper, VideoItem, Thumbnail } from '../style';
 
 function OtherVideo({
   member: { socketID, loginID, username, thumbnail, cam, speaker, mic, stream, screen, pc },
   muted,
+  selectVideo,
 }: {
   member: IMeetingUser;
   muted: boolean;
+  selectVideo: (videoInfo: SelectedVideo) => (e: any) => void;
 }) {
   const camRef = useRef<HTMLVideoElement>(null);
   const screenRef = useRef<HTMLVideoElement>(null);
+  const videoInfo = {
+    socketID,
+    loginID,
+    username,
+    thumbnail,
+    stream,
+    mic,
+    cam,
+    speaker,
+  };
 
   useEffect(() => {
     if (!camRef.current || !stream) return;
@@ -44,7 +56,16 @@ function OtherVideo({
   return (
     <>
       <VideoItemWrapper>
-        <VideoItem muted={muted} autoPlay playsInline ref={camRef} />
+        <VideoItem
+          muted={muted}
+          autoPlay
+          playsInline
+          ref={camRef}
+          onClick={selectVideo({
+            ...videoInfo,
+            isScreen: true,
+          })}
+        />
         <p>{`${username}(${loginID})`}</p>
         {mic || <MicOffIcon />}
         {speaker || <SpeakerOffIcon />}
@@ -54,7 +75,17 @@ function OtherVideo({
       </VideoItemWrapper>
       {screen && (
         <VideoItemWrapper>
-          <VideoItem key={socketID} muted={muted} autoPlay playsInline ref={screenRef} />
+          <VideoItem
+            key={socketID}
+            muted={muted}
+            autoPlay
+            playsInline
+            ref={screenRef}
+            onClick={selectVideo({
+              ...videoInfo,
+              isScreen: true,
+            })}
+          />
           <p>{`${username}(${loginID})님의 화면`}</p>
         </VideoItemWrapper>
       )}

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect } from 'react';
 
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
 import { IMeetingUser, SelectedVideo } from '..';
-import { VideoItemWrapper, VideoItem, Thumbnail } from '../style';
+import { VideoWrapper, Video, Thumbnail } from '../style';
 
 function OtherVideo({
   member: { socketID, loginID, username, thumbnail, cam, speaker, mic, stream, screen, pc },
@@ -55,8 +55,8 @@ function OtherVideo({
 
   return (
     <>
-      <VideoItemWrapper>
-        <VideoItem
+      <VideoWrapper>
+        <Video
           muted={muted}
           autoPlay
           playsInline
@@ -72,10 +72,10 @@ function OtherVideo({
         {cam || (
           <Thumbnail src={thumbnail || '/images/default_profile.png'} alt="profile"></Thumbnail>
         )}
-      </VideoItemWrapper>
+      </VideoWrapper>
       {screen && (
-        <VideoItemWrapper>
-          <VideoItem
+        <VideoWrapper>
+          <Video
             key={socketID}
             muted={muted}
             autoPlay
@@ -87,7 +87,7 @@ function OtherVideo({
             })}
           />
           <p>{`${username}(${loginID})님의 화면`}</p>
-        </VideoItemWrapper>
+        </VideoWrapper>
       )}
     </>
   );

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -7,7 +7,7 @@ import { highlightMyVolume } from 'src/utils/audio';
 import OtherVideo from './OtherVideo';
 import MeetButton from './MeetButton';
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import { MeetVideoWrapper, VideoItemWrapper, VideoItem, Thumbnail } from './style';
+import { Videos, VideoWrapper, Video, Thumbnail, VideoSection } from './style';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
 
@@ -343,13 +343,13 @@ function MeetVideo() {
   }, []);
 
   return (
-    <>
+    <VideoSection>
       {selectedVideo && (
         <FocusedVideo selectedVideo={selectedVideo} deselectVideo={deselectVideo} />
       )}
-      <MeetVideoWrapper ref={videoWrapperRef} videoCount={videoCount || 0}>
-        <VideoItemWrapper>
-          <VideoItem autoPlay playsInline muted ref={myVideoRef} />
+      <Videos ref={videoWrapperRef} videoCount={videoCount || 0}>
+        <VideoWrapper>
+          <Video autoPlay playsInline muted ref={myVideoRef} />
           {cam ? (
             ''
           ) : (
@@ -358,12 +358,12 @@ function MeetVideo() {
           <p>{`${userdata?.username}(${userdata?.loginID})`}</p>
           {mic ? '' : <MicOffIcon />}
           {speaker ? '' : <SpeakerOffIcon />}
-        </VideoItemWrapper>
+        </VideoWrapper>
         {screenShare && (
-          <VideoItemWrapper>
-            <VideoItem autoPlay playsInline muted ref={myScreenRef} />
+          <VideoWrapper>
+            <Video autoPlay playsInline muted ref={myScreenRef} />
             <p>{`${userdata?.username}(${userdata?.loginID})님의 화면`}</p>
-          </VideoItemWrapper>
+          </VideoWrapper>
         )}
         {meetingMembers.map((member) => (
           <OtherVideo
@@ -373,7 +373,7 @@ function MeetVideo() {
             selectVideo={selectVideo}
           />
         ))}
-      </MeetVideoWrapper>
+      </Videos>
       <MeetButton
         onScreenShareClick={() => {
           if (screenShare) {
@@ -385,7 +385,7 @@ function MeetVideo() {
           }
         }}
       />
-    </>
+    </VideoSection>
   );
 }
 

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -378,6 +378,7 @@ function MeetVideo() {
             member={member}
             muted={!speaker}
             selectVideo={selectVideo}
+            selectedVideo={selectedVideo}
           />
         ))}
       </Videos>

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 
-import { useSelectedChannel, useSelectedGroup, useUserdata, useUserDevice } from '@hooks/index';
+import {
+  useSelectedChannel,
+  useSelectedGroup,
+  useSelectVideo,
+  useUserdata,
+  useUserDevice,
+} from '@hooks/index';
 import MeetEvent from '@customTypes/socket/MeetEvent';
 import Socket, { socket } from 'src/utils/socket';
 import { highlightMyVolume } from 'src/utils/audio';
@@ -84,18 +90,7 @@ function MeetVideo() {
   const [meetingMembers, setMeetingMembers] = useState<IMeetingUser[]>([]);
   const pcs = useRef<{ [socketID: string]: RTCPeerConnection }>({});
   const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
-  const [selectedVideo, setSelectedVideo] = useState<SelectedVideo | null>(null);
-
-  const deselectVideo = () => setSelectedVideo(null);
-  const selectVideo = useCallback(
-    (videoInfo: SelectedVideo) => () => {
-      setSelectedVideo((selectedVideo) => {
-        if (selectedVideo?.stream?.id === videoInfo?.stream?.id) return null;
-        else return { ...videoInfo };
-      });
-    },
-    [],
-  );
+  const { selectVideo, deselectVideo, selectedVideo, setSelectedVideo } = useSelectVideo();
 
   const getMyStream = async () => {
     let myStream;

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -8,6 +8,7 @@ import OtherVideo from './OtherVideo';
 import MeetButton from './MeetButton';
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
 import { Videos, VideoWrapper, Video, Thumbnail, VideoSection } from './style';
+import FocusedVideo from './FocusedVideo';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
 
@@ -344,10 +345,8 @@ function MeetVideo() {
 
   return (
     <VideoSection>
-      {selectedVideo && (
-        <FocusedVideo selectedVideo={selectedVideo} deselectVideo={deselectVideo} />
-      )}
-      <Videos ref={videoWrapperRef} videoCount={videoCount || 0}>
+      {selectedVideo && <FocusedVideo selectedVideo={selectedVideo} onClick={deselectVideo} />}
+      <Videos ref={videoWrapperRef} videoCount={videoCount || 0} focused={selectedVideo !== null}>
         <VideoWrapper>
           <Video autoPlay playsInline muted ref={myVideoRef} />
           {cam ? (
@@ -386,27 +385,6 @@ function MeetVideo() {
         }}
       />
     </VideoSection>
-  );
-}
-
-function FocusedVideo({
-  selectedVideo,
-  deselectVideo,
-}: {
-  selectedVideo: SelectedVideo;
-  deselectVideo: () => void;
-}) {
-  const videoRef = useRef<HTMLVideoElement>(null);
-
-  useEffect(() => {
-    if (videoRef.current && selectedVideo.stream) videoRef.current.srcObject = selectedVideo.stream;
-  }, [selectedVideo]);
-
-  return (
-    <div>
-      <video autoPlay playsInline ref={videoRef} onClick={deselectVideo} />
-      {selectedVideo?.username}
-    </div>
   );
 }
 

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -7,7 +7,15 @@ import { highlightMyVolume } from 'src/utils/audio';
 import OtherVideo from './OtherVideo';
 import MeetButton from './MeetButton';
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import { Videos, VideoWrapper, Video, Thumbnail, VideoSection } from './style';
+import {
+  Videos,
+  VideoWrapper,
+  Video,
+  Thumbnail,
+  VideoSection,
+  DeviceStatus,
+  ThumbnailWrapper,
+} from './style';
 import FocusedVideo from './FocusedVideo';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
@@ -352,19 +360,21 @@ function MeetVideo() {
       <Videos ref={videoWrapperRef} videoCount={videoCount || 0} focused={selectedVideo !== null}>
         <VideoWrapper>
           <Video autoPlay playsInline muted ref={myVideoRef} />
-          {cam ? (
-            ''
-          ) : (
-            <Thumbnail src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
-          )}
+          <ThumbnailWrapper>
+            {cam || (
+              <Thumbnail src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
+            )}
+          </ThumbnailWrapper>
           <p>{`${userdata?.username}(${userdata?.loginID})`}</p>
-          {mic ? '' : <MicOffIcon />}
-          {speaker ? '' : <SpeakerOffIcon />}
+          <DeviceStatus>
+            {mic || <MicOffIcon />}
+            {speaker || <SpeakerOffIcon />}
+          </DeviceStatus>
         </VideoWrapper>
         {screenShare && (
           <VideoWrapper>
             <Video autoPlay playsInline muted ref={myScreenRef} />
-            <p>{`${userdata?.username}(${userdata?.loginID})님의 화면`}</p>
+            <p>{`${userdata?.username}(${userdata?.loginID}) 님의 화면`}</p>
           </VideoWrapper>
         )}
         {meetingMembers.map((member) => (

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -319,6 +319,11 @@ function MeetVideo() {
       setMeetingMembers((members) => {
         const member = members.find((member) => member.socketID === socketID);
         if (!member) return members;
+        setSelectedVideo((selectedVideo) => {
+          if (selectedVideo?.socketID === member.socketID)
+            return { ...selectedVideo, mic: micStatus };
+          else return selectedVideo;
+        });
         member.mic = micStatus;
         return [...members];
       });
@@ -328,16 +333,26 @@ function MeetVideo() {
       setMeetingMembers((members) => {
         const member = members.find((member) => member.socketID === socketID);
         if (!member) return members;
+        setSelectedVideo((selectedVideo) => {
+          if (selectedVideo?.socketID === member.socketID)
+            return { ...selectedVideo, cam: camStatus };
+          else return selectedVideo;
+        });
         member.cam = camStatus;
         return [...members];
       });
     });
 
-    socket.on(MeetEvent.setSpeaker, (speakerStatue, socketID) => {
+    socket.on(MeetEvent.setSpeaker, (speakerStatus, socketID) => {
       setMeetingMembers((members) => {
         const member = members.find((member) => member.socketID === socketID);
         if (!member) return members;
-        member.speaker = speakerStatue;
+        setSelectedVideo((selectedVideo) => {
+          if (selectedVideo?.socketID === member.socketID)
+            return { ...selectedVideo, speaker: speakerStatus };
+          else return selectedVideo;
+        });
+        member.speaker = speakerStatus;
         return [...members];
       });
     });

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -80,8 +80,11 @@ function MeetVideo() {
 
   const deselectVideo = () => setSelectedVideo(null);
   const selectVideo = useCallback(
-    (videoInfo: SelectedVideo) => (e: any) => {
-      setSelectedVideo(videoInfo);
+    (videoInfo: SelectedVideo) => () => {
+      setSelectedVideo((selectedVideo) => {
+        if (selectedVideo?.stream?.id === videoInfo?.stream?.id) return null;
+        else return { ...videoInfo };
+      });
     },
     [],
   );

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -67,7 +67,7 @@ const VideoWrapper = styled.div`
     padding: 3px 8px;
     border-radius: 5px;
     color: ${Colors.White};
-    background-color: rgba(0, 0, 0, 0.3);
+    background-color: rgba(255, 255, 255, 0.3);
   }
   .saying {
     border: 3px solid ${Colors.Blue};
@@ -97,7 +97,7 @@ const Video = styled.video`
   height: 100%;
   object-fit: contain;
   border-radius: 20px;
-  background-color: ${Colors.Gray4};
+  background-color: black;
 `;
 
 const DeviceStatus = styled.div`

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -1,11 +1,12 @@
 import Colors from '@styles/Colors';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-interface IMeetVideoWrapper {
+interface VideosProps {
   videoCount: number;
+  focused: boolean;
 }
 
-const Videos = styled.div<IMeetVideoWrapper>`
+const normal = css<VideosProps>`
   margin: 0 auto;
   display: grid;
   width: 100%;
@@ -22,52 +23,87 @@ const Videos = styled.div<IMeetVideoWrapper>`
       : 'max-width: 1500px; grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));'}
 `;
 
+const focused = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 300px;
+  max-width: 300px;
+  height: 100%;
+  padding: 20px;
+`;
+
+const Videos = styled.div<VideosProps>`
+  ${(props) => (props.focused ? focused : normal)}
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${Colors.Gray2};
+    border-radius: 10px;
+  }
+
+  &:hover::-webkit-scrollbar {
+    display: block;
+    width: 15px;
+  }
+`;
+
 const VideoWrapper = styled.div`
+  position: relative;
   width: 100%;
   max-width: 700px;
-  height: 100%;
+  height: 0;
+  padding-bottom: 56.25%;
+  border-radius: 20px;
   justify-self: center;
   align-self: center;
   display: flex;
-  justify-content: center;
-  align-items: center;
   flex-direction: column;
+
+  margin-bottom: 10px;
   & p {
+    position: absolute;
+    bottom: 10px;
     align-self: center;
+    color: ${Colors.White};
   }
   .saying {
     border: 3px solid ${Colors.Blue};
   }
-  img {
-    display: block;
-    position: absolute;
-  }
 `;
 
 const Thumbnail = styled.img`
+  display: block;
+  position: absolute;
+  margin: auto 0;
+  align-self: center;
   width: 100px;
   height: 100px;
   object-fit: cover;
   border-radius: 50%;
-  position: absolute;
 `;
 
 const Video = styled.video`
+  position: absolute;
   width: 100%;
-  max-width: 700px;
-  border-radius: 20px;
-  justify-self: center;
+  height: 100%;
+  object-fit: contain;
+  margin: auto 0;
   align-self: center;
-  margin-bottom: 10px;
+  border-radius: 20px;
+  background-color: ${Colors.Black};
 `;
 
 const VideoSection = styled.section`
   display: flex;
-  flex-direction: column;
+  justify-content: end;
   background-color: ${Colors.Gray3};
   width: 100%;
   height: 100%;
-  padding: 10px;
 `;
 
 export { Videos, VideoWrapper, Video, Thumbnail, VideoSection };

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -83,6 +83,16 @@ const ThumbnailWrapper = styled.div`
   height: 100%;
 `;
 
+const SelectVideoIndicator = styled(ThumbnailWrapper)`
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 20px;
+
+  svg {
+    width: 80px;
+    height: 80px;
+  }
+`;
+
 const Thumbnail = styled.img`
   display: block;
   width: 100px;
@@ -119,4 +129,13 @@ const VideoSection = styled.section`
   height: 100%;
 `;
 
-export { Videos, VideoWrapper, Video, Thumbnail, ThumbnailWrapper, VideoSection, DeviceStatus };
+export {
+  Videos,
+  VideoWrapper,
+  Video,
+  Thumbnail,
+  ThumbnailWrapper,
+  VideoSection,
+  DeviceStatus,
+  SelectVideoIndicator,
+};

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -58,29 +58,33 @@ const VideoWrapper = styled.div`
   max-width: 700px;
   height: 0;
   padding-bottom: 56.25%;
-  border-radius: 20px;
-  justify-self: center;
-  align-self: center;
-  display: flex;
-  flex-direction: column;
-
   margin-bottom: 10px;
+
   & p {
     position: absolute;
     bottom: 10px;
-    align-self: center;
+    left: 10px;
+    padding: 3px 8px;
+    border-radius: 5px;
     color: ${Colors.White};
+    background-color: rgba(0, 0, 0, 0.3);
   }
   .saying {
     border: 3px solid ${Colors.Blue};
   }
 `;
 
+const ThumbnailWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+`;
+
 const Thumbnail = styled.img`
   display: block;
-  position: absolute;
-  margin: auto 0;
-  align-self: center;
   width: 100px;
   height: 100px;
   object-fit: cover;
@@ -92,10 +96,19 @@ const Video = styled.video`
   width: 100%;
   height: 100%;
   object-fit: contain;
-  margin: auto 0;
-  align-self: center;
   border-radius: 20px;
-  background-color: ${Colors.Black};
+  background-color: ${Colors.Gray4};
+`;
+
+const DeviceStatus = styled.div`
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 10;
+
+  svg {
+    margin-right: 5px;
+  }
 `;
 
 const VideoSection = styled.section`
@@ -106,4 +119,4 @@ const VideoSection = styled.section`
   height: 100%;
 `;
 
-export { Videos, VideoWrapper, Video, Thumbnail, VideoSection };
+export { Videos, VideoWrapper, Video, Thumbnail, ThumbnailWrapper, VideoSection, DeviceStatus };

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -5,7 +5,7 @@ interface IMeetVideoWrapper {
   videoCount: number;
 }
 
-const MeetVideoWrapper = styled.div<IMeetVideoWrapper>`
+const Videos = styled.div<IMeetVideoWrapper>`
   margin: 0 auto;
   display: grid;
   width: 100%;
@@ -22,7 +22,7 @@ const MeetVideoWrapper = styled.div<IMeetVideoWrapper>`
       : 'max-width: 1500px; grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));'}
 `;
 
-const VideoItemWrapper = styled.div`
+const VideoWrapper = styled.div`
   width: 100%;
   max-width: 700px;
   height: 100%;
@@ -52,7 +52,7 @@ const Thumbnail = styled.img`
   position: absolute;
 `;
 
-const VideoItem = styled.video`
+const Video = styled.video`
   width: 100%;
   max-width: 700px;
   border-radius: 20px;
@@ -61,4 +61,13 @@ const VideoItem = styled.video`
   margin-bottom: 10px;
 `;
 
-export { MeetVideoWrapper, VideoItemWrapper, VideoItem, Thumbnail };
+const VideoSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  background-color: ${Colors.Gray3};
+  width: 100%;
+  height: 100%;
+  padding: 10px;
+`;
+
+export { Videos, VideoWrapper, Video, Thumbnail, VideoSection };

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -88,8 +88,11 @@ const SelectVideoIndicator = styled(ThumbnailWrapper)`
   border-radius: 20px;
 
   svg {
-    width: 80px;
-    height: 80px;
+    width: 50px;
+    height: 50px;
+    path {
+      fill: ${Colors.Gray3};
+    }
   }
 `;
 

--- a/client/src/components/Meet/index.tsx
+++ b/client/src/components/Meet/index.tsx
@@ -2,15 +2,13 @@ import React from 'react';
 
 import MeetVideo from './MeetVideo';
 import MeetChat from './MeetChat';
-import { MeetWrapper, VideoSection } from './style';
+import { MeetWrapper } from './style';
 
 function Meet() {
   return (
     <MeetWrapper>
       <MeetChat />
-      <VideoSection>
-        <MeetVideo />
-      </VideoSection>
+      <MeetVideo />
     </MeetWrapper>
   );
 }

--- a/client/src/components/Meet/style.ts
+++ b/client/src/components/Meet/style.ts
@@ -8,13 +8,4 @@ const MeetWrapper = styled.div`
   height: calc(100% - 50px);
 `;
 
-const VideoSection = styled.section`
-  display: flex;
-  flex-direction: column;
-  background-color: ${Colors.Gray3};
-  width: 100%;
-  height: 100%;
-  padding: 10px;
-`;
-
-export { MeetWrapper, VideoSection };
+export { MeetWrapper };

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -8,3 +8,4 @@ export * from './useUserDevice';
 export * from './useUserdata';
 export * from './useSelectedUser';
 export * from './useOtherUserdata';
+export * from './useSelectVideo';

--- a/client/src/hooks/useSelectVideo.ts
+++ b/client/src/hooks/useSelectVideo.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback } from 'react';
+import { SelectedVideo } from '@components/Meet/MeetVideo';
+
+export const useSelectVideo = () => {
+  const [selectedVideo, setSelectedVideo] = useState<SelectedVideo | null>(null);
+
+  const deselectVideo = () => setSelectedVideo(null);
+  const selectVideo = useCallback(
+    (videoInfo: SelectedVideo) => () => {
+      setSelectedVideo((selectedVideo) => {
+        if (selectedVideo?.stream?.id === videoInfo?.stream?.id) return null;
+        else return { ...videoInfo };
+      });
+    },
+    [],
+  );
+
+  return { selectVideo, deselectVideo, selectedVideo, setSelectedVideo };
+};


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #298

## What did you do?
화상 회의 채널에서 이제 나 자신을 제외한 다른 사용자의 비디오를 클릭시 크게 볼 수 있습니다!
redux 스토어에 non serializable value(Date, MediaStream 객체 등)를 저장할 경우 스토어의 일관성 유지가 어렵고 복원, 시간여행 디버깅 등의 기능 사용에 문제가 발생할 수 있습니다. 저희의 경우 선택된 비디오 stream을 redux 스토어에 저장할 경우 상대방이 회의에서 나가거나 화면공유가 중단되는 등 stream에 변동이 생겼을 때 stream 상태가 mutate 될 수 있고, 이 경우 redux의 기본 미들웨어인 redux-immutable-state-invariant 에서 에러를 발생시킵니다. 이는 상태는 항상 immutable 해야하는  redux의 원칙에 위배되는 것이기 때문입니다. redux-immutable-state-invariant 미들웨어는 개발시에만 사용되어 stream을 redux 스토어에 저장하더라도 배포시 동작에는 큰 문제가 없지만 바람직하지 못한 사용방식이기 때문에 useState를 통해 선택된 비디오의 상태를 MeetVideo 컴포넌트에서 관리하도록 하였습니다.
 useState를 이용해 부모 컴포넌트에서 상태를 관리하고 props로 상태 변경을 위한 onClick 이벤트 핸들러와 상태값을 내려주도록 구현하였습니다. 때문에 MeetVideo 코드가 더 복잡해져 해당 로직을 커스텀 훅으로 분리하였습니다. 추후 코드를 좀 더 깔끔하게 정리할 필요가 있어보입니다.

<!--무엇을 하셨나요?-->
- [x] 화상 회의 채널에서 다른 사용자의 비디오를 클릭시 크게 볼 수 있다.
- [x] 화상 회의 채널 레이아웃 수정

![화면확대기능4](https://user-images.githubusercontent.com/77329061/142958558-d79598db-8909-4a0f-8a3d-943dfadaf771.gif)

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
CSS 너무 어-썸

## 레퍼런스
https://redux.js.org/style-guide/style-guide#do-not-put-non-serializable-values-in-state-or-actions
https://github.com/leoasis/redux-immutable-state-invariant
https://redux.js.org/style-guide/style-guide#do-not-mutate-state
https://redux.js.org/usage/troubleshooting#never-mutate-reducer-arguments
