### PR TITLE
Fix : MeetChat의 input이 MeetButtonWrapper에 가려져서 클릭하지 못하는 문제 수정

### DIFF
--- a/client/src/components/Meet/MeetVideo/MeetButton/style.ts
+++ b/client/src/components/Meet/MeetVideo/MeetButton/style.ts
@@ -3,11 +3,9 @@ import Colors from '@styles/Colors';
 
 const MeetButtonWrapper = styled.div`
   position: absolute;
-  left: auto;
-  right: auto;
+  left: 50%;
   bottom: 10px;
-  width: 100%;
-  height: 10%;
+  transform: translateX(-50%);
   display: flex;
   justify-content: center;
   & button {

--- a/client/src/components/Meet/MeetVideo/style.ts
+++ b/client/src/components/Meet/MeetVideo/style.ts
@@ -125,6 +125,7 @@ const DeviceStatus = styled.div`
 `;
 
 const VideoSection = styled.section`
+  position: relative;
   display: flex;
   justify-content: end;
   background-color: ${Colors.Gray3};


### PR DESCRIPTION
## What did you do?
MeetChat의 input이 MeetButtonWrapper에 가려져서 클릭하지 못하는 문제 수정했습니다...
다시 채팅을 보낼 수 있읍니다.
<!--무엇을 하셨나요?-->
- [x] MeetChat의 input이 MeetButtonWrapper에 가려져서 클릭하지 못하는 문제 수정
