### PR TITLE
Fix : ontrack 이벤트 핸들러에서 cam과 screen 스트림을 streamID로 구분하도록 수정

### DIFF
--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -51,12 +51,16 @@ function SocketMeetController(socket) {
     io.to(socket.id).emit(MeetEvent.allMeetingMembers, membersInMeeting);
   };
 
-  this.answer = ({ answer, receiverID }) => {
-    io.to(receiverID).emit(MeetEvent.answer, { answer, senderID: socket.id });
+  this.offer = ({ offer, receiverID, member, streamID }) => {
+    io.to(receiverID).emit(MeetEvent.offer, {
+      offer,
+      member: { socketID: socket.id, ...member },
+      streamID,
+    });
   };
 
-  this.offer = ({ offer, receiverID, member }) => {
-    io.to(receiverID).emit(MeetEvent.offer, { offer, member: { socketID: socket.id, ...member } });
+  this.answer = ({ answer, receiverID, streamID }) => {
+    io.to(receiverID).emit(MeetEvent.answer, { answer, senderID: socket.id, streamID });
   };
 
   this.candidate = ({ candidate, receiverID }) => {


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #313 
## What did you do?
ontrack 이벤트 핸들러에서 camera와 screen 스트림을 streamID로 구분하도록 수정하였습니다.
RTC 연결을 과정 중 offer와 answer를 시그널링 하는 과정에서 streamID 메타 데이터를 주고 받습니다.
streamID 메타 데이터는 camera, screen 스트림 각각의 id를 갖고 있습니다.
전달 받은 streamID를 ontrack 이벤트로 전달받은 새 트랙의 streamID와 비교해 새 stream이 어떤 타입의 stream인지 구분해 처리합니다.
```
interface StreamMetaData {
  camera: cameraStreamID;
  screen: screenStreamID;
}
```
<!--무엇을 하셨나요?-->
- [x] ontrack 이벤트 핸들러 스트림 타입 구분 로직 수정
