### PR TITLE
Fix : 불필요한 모듈 가져오기 제거, 채널리스트 아이템의 아이콘 z-index 수정

### DIFF
--- a/client/src/components/Meet/style.ts
+++ b/client/src/components/Meet/style.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import Colors from '../../styles/Colors';
 
 const MeetWrapper = styled.div`
   position: relative;

--- a/client/src/components/SideBar/Channels/ChannelListItem/style.ts
+++ b/client/src/components/SideBar/Channels/ChannelListItem/style.ts
@@ -28,7 +28,6 @@ const ListItem = styled.li<IListItem>`
       width: 24px;
       height: 24px;
       margin-right: 5px;
-      z-index: 99;
     }
     & p {
       max-width: 180px;


### PR DESCRIPTION
## What did you do?
채널리스트 아이콘이 다른 요소를 가려 확인해보니 z-index가 99로 설정되어 있었습니다.
Meet컴포넌트 스타일 파일에 Colors가 사용되지 않는데 불필요하게 가져오고 있어서 제거했습니다.

<!--무엇을 하셨나요?-->
- [x] 불필요한 모듈 가져오기 제거
- [x] 채널리스트 아이템의 아이콘 z-index 수정 
