### PR TITLE
[Fix/InfinityScroll] 무한 스크롤 로직 수정

### DIFF
--- a/client/src/utils/functionalProgramming.ts
+++ b/client/src/utils/functionalProgramming.ts
@@ -24,7 +24,7 @@ const mapAsync = curry((f: (a: Promise<any>) => Promise<any>, iter: any) => {
   for (const a of iter) {
     res.push(a.then(f));
   }
-  return res;
+  return Promise.all(res);
 });
 
 const reduce = curry((f: (a: any, b: any) => any, acc: any, iter: any) => {
@@ -38,22 +38,8 @@ const reduce = curry((f: (a: any, b: any) => any, acc: any, iter: any) => {
   return acc;
 });
 
-const reduceAsync = curry(async (f: (a: number, b: number) => number, acc: any, iter: any) => {
-  if (!iter) {
-    iter = acc[Symbol.iterator]();
-    acc = await iter.next().value;
-  }
-  for await (const ab of iter) {
-    acc = f(acc, ab);
-  }
-  return acc;
-});
-
 const go = (...args: any) => reduce((a: any, f: any) => f(a), args, undefined);
 
-const add = curry(async (a: number, b: Promise<number>) => {
-  const totalHeight = await b;
-  return totalHeight + a;
-});
+const add = curry((a: number, b: number) => a + b);
 
-export { map, mapAsync, filter, reduceAsync, go, add };
+export { map, mapAsync, filter, reduce, go, add };

--- a/client/src/utils/getChatsHeight.ts
+++ b/client/src/utils/getChatsHeight.ts
@@ -1,4 +1,4 @@
-import { map, mapAsync, reduceAsync, filter, go, add } from './functionalProgramming';
+import { map, mapAsync, filter, go, add, reduce } from './functionalProgramming';
 import { makeChatSection } from './makeChatSection';
 
 const addEventToImg = (img: HTMLElement) =>
@@ -6,7 +6,7 @@ const addEventToImg = (img: HTMLElement) =>
     img.onload = () => resolve();
   });
 
-const loadOneChatItemImages = (chatItem: HTMLElement) =>
+const addLoadEvent = (chatItem: HTMLElement) =>
   Promise.all(go(chatItem.querySelectorAll('img'), map(addEventToImg)));
 
 const getChatsHeight = async (chatListRef: React.RefObject<HTMLDivElement>, length: number) => {
@@ -14,23 +14,16 @@ const getChatsHeight = async (chatListRef: React.RefObject<HTMLDivElement>, leng
   const target = filter(chatItems, length);
   const dayPillHeights = Object.keys(makeChatSection(target)).length * 30;
 
-  let count = -1;
+  const loadImage = () => new Promise<void>((resolve) => resolve());
 
-  const getOneElement = () =>
-    new Promise((resolve) => {
-      count += 1;
-      return resolve(target[count].clientHeight);
-    });
+  await go(target, map(addLoadEvent), mapAsync(loadImage));
 
-  const result = go(
+  return go(
     target,
-    map(loadOneChatItemImages),
-    mapAsync(getOneElement),
-    reduceAsync((a: number, b: number) => a + b),
+    map((chatItem: HTMLElement) => chatItem.clientHeight),
+    reduce(add),
     add(dayPillHeights),
   );
-
-  return result;
 };
 
 export { getChatsHeight };


### PR DESCRIPTION
## What did you do?
기존의 로직을 수정하였습니다. 그리고  모든 이미지를 병렬로 불러올 수 있도록 구현하였습니다.
<!--무엇을 하셨나요?-->
- [x]  로직 수정 
- [x] 모든 이미지를 병렬로 불러올 수 있도록 구현

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
몇일 동안 이 기능에 집착해서 죄송합니다! 그래도 완벽하게 해보고싶은 마음에 많은 시도를 해봤습니다.
```
await go(
  target, 
  map(addLoadEvent), 
  mapAsync(loadImage)
);
// 모든 이미지를 불러옵니다. 

// 이후에 높이를 계산해서 반환합니다.
return go(
  target,
  map((chatItem: HTMLElement) => chatItem.clientHeight),
  reduce(add),
  add(dayPillHeights),
);
```

