### PR TITLE
Fix : useSoundEffect를 playSoundEffect 유틸 함수로 변경

### DIFF
--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -6,8 +6,6 @@ import {
   useSelectVideo,
   useUserdata,
   useUserDevice,
-  useSoundEffect,
-  SoundEffect,
 } from '@hooks/index';
 import MeetEvent from '@customTypes/socket/MeetEvent';
 import Socket, { socket } from 'src/utils/socket';
@@ -25,6 +23,7 @@ import {
   ThumbnailWrapper,
 } from './style';
 import FocusedVideo from './FocusedVideo';
+import { playSoundEffect, SoundEffect } from 'src/utils/playSoundEffect';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
 
@@ -99,7 +98,6 @@ function MeetVideo() {
   const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
   const { selectVideo, deselectVideo, selectedVideo, setSelectedVideo } = useSelectVideo();
   const streamIDMetaData = useRef<{ [socketID: string]: StreamIDMetaData }>({});
-  const playSoundEffect = useSoundEffect();
 
   const getMyStream = async () => {
     let myStream;

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -10,4 +10,3 @@ export * from './useSelectedUser';
 export * from './useOtherUserdata';
 export * from './useToast';
 export * from './useSelectVideo';
-export * from './useSoundEffect';

--- a/client/src/utils/playSoundEffect.ts
+++ b/client/src/utils/playSoundEffect.ts
@@ -2,16 +2,12 @@ const soundFileNames = ['meet_join.wav', 'meet_leave.wav'];
 const SOUNDS_PATH = '/sounds/';
 const soundEffects = soundFileNames.map((filename) => new Audio(SOUNDS_PATH + filename));
 
-export const useSoundEffect = () => {
-  const playSoundEffect = (soundEffect: SoundEffect) => {
-    try {
-      soundEffects[soundEffect].play();
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  return playSoundEffect;
+export const playSoundEffect = (soundEffect: SoundEffect) => {
+  try {
+    soundEffects[soundEffect].play();
+  } catch (e) {
+    console.error(e);
+  }
 };
 
 export enum SoundEffect {


### PR DESCRIPTION
## What did you do?
기존에는 Audio 태그에 ref를 달고 useEffect에서 Audio태그를 play 해주는 방법으로 구현해 커스텀 훅으로 분리했었습니다.
그러나 Audio 인터페이스 객체를 play 해주는 방식으로 변경되어 useEffect, useRef가 쓰이지 않게 되어 더 이상 커스텀 훅이 아니게 되었는데, 그럼에도 파일명과 함수 이름을 수정하지 않고 의미없이 함수로 감싸 반환하는 요상한 코드로 되어 있어 수정했습니다.
<!--무엇을 하셨나요?-->
- [x]  더 이상 커스텀훅이 아닌 useSoundEffect를 playSoundEffect 유틸함수로 변경

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
제대로 확인 안하고 무지성 커밋/PR해서 죄송합니다 ㅠㅠ
요즘 컨디션이 말이 아니네요....
