### PR TITLE
MeetVideo 컴포넌트 리팩토링 및 새로고침시 연결이 안되는 버그 수정, 로딩 스크린 추가, 프론트 소켓 연결 개선

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,8 +7,14 @@ import GlobalStyle from '@styles/GlobalStyle';
 import { Switch } from 'react-router-dom';
 import RestrictedRoute from '@components/common/RestrictedRoute';
 import Toast from '@components/common/Toast';
+import { useSocket } from '@hooks/index';
+import Loading from '@pages/Loading';
 
 function App() {
+  const isLoading = useSocket();
+
+  if (isLoading) return <Loading />;
+
   return (
     <div className="App">
       <GlobalStyle />

--- a/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/FocusedVideo/index.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 
 import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import { SelectedVideo } from '..';
+
 import { ThumbnailWrapper, Thumbnail } from '../style';
 import { UserInfo, Video, VideoWrapper, DeviceStatus } from './style';
+import { SelectedVideo } from '@customTypes/meet';
 
 function FocusedVideo({
   selectedVideo: { loginID, username, stream, thumbnail, mic, cam, speaker, isScreen },

--- a/client/src/components/Meet/MeetVideo/MeetButton/style.ts
+++ b/client/src/components/Meet/MeetVideo/MeetButton/style.ts
@@ -4,7 +4,7 @@ import Colors from '@styles/Colors';
 const MeetButtonWrapper = styled.div`
   position: absolute;
   left: 50%;
-  bottom: 10px;
+  bottom: 0;
   transform: translateX(-50%);
   display: flex;
   justify-content: center;

--- a/client/src/components/Meet/MeetVideo/MyVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/MyVideo/index.tsx
@@ -1,0 +1,43 @@
+import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
+import React, { RefObject } from 'react';
+
+import { useUserdata } from '@hooks/useUserdata';
+import { VideoWrapper, Video, ThumbnailWrapper, Thumbnail, DeviceStatus } from '../style';
+
+interface MyVideoProps {
+  myVideoRef: RefObject<HTMLVideoElement>;
+  myScreenRef: RefObject<HTMLVideoElement>;
+  cam: boolean;
+  mic: boolean;
+  speaker: boolean;
+  screenShare: boolean;
+}
+
+function MyVideo({ myVideoRef, myScreenRef, cam, mic, speaker, screenShare }: MyVideoProps) {
+  const { userdata } = useUserdata();
+  return (
+    <>
+      <VideoWrapper>
+        <Video autoPlay playsInline muted ref={myVideoRef} />
+        <ThumbnailWrapper>
+          {cam || (
+            <Thumbnail src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
+          )}
+        </ThumbnailWrapper>
+        <p>{`${userdata?.username}(${userdata?.loginID})`}</p>
+        <DeviceStatus>
+          {mic || <MicOffIcon />}
+          {speaker || <SpeakerOffIcon />}
+        </DeviceStatus>
+      </VideoWrapper>
+      {screenShare && (
+        <VideoWrapper>
+          <Video autoPlay playsInline muted ref={myScreenRef} />
+          <p>{`${userdata?.username}(${userdata?.loginID}) 님의 화면`}</p>
+        </VideoWrapper>
+      )}
+    </>
+  );
+}
+
+export default MyVideo;

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 
 import { CameraOnIcon, MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import { IMeetingUser, SelectedVideo } from '..';
+import { MeetingMember, SelectedVideo } from '..';
 import {
   VideoWrapper,
   Video,
@@ -17,7 +17,7 @@ function OtherVideo({
   selectVideo,
   selectedVideo,
 }: {
-  member: IMeetingUser;
+  member: MeetingMember;
   muted: boolean;
   selectVideo: (videoInfo: SelectedVideo) => () => void;
   selectedVideo: SelectedVideo | null;

--- a/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/OtherVideo/index.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 
 import { CameraOnIcon, MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import { MeetingMember, SelectedVideo } from '..';
+
 import {
   VideoWrapper,
   Video,
@@ -10,6 +10,7 @@ import {
   ThumbnailWrapper,
   SelectVideoIndicator,
 } from '../style';
+import { MeetingMember, SelectedVideo } from '@customTypes/meet';
 
 function OtherVideo({
   member: { socketID, loginID, username, thumbnail, cam, speaker, mic, stream, screen, pc },

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -17,6 +17,7 @@ import MeetButton from './MeetButton';
 import { Videos, VideoSection } from './style';
 import FocusedVideo from './FocusedVideo';
 import MyVideo from './MyVideo';
+import { MeetingMember, StreamIDMetaData } from '@customTypes/meet';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
 
@@ -44,36 +45,6 @@ const applyDeviceStatus = ({
     track.enabled = audio;
   });
 };
-
-export interface MeetingMember {
-  socketID: string;
-  loginID: string;
-  username: string;
-  thumbnail: string | null;
-  mic: boolean;
-  cam: boolean;
-  speaker: boolean;
-  stream?: MediaStream;
-  screen?: MediaStream;
-  pc?: RTCPeerConnection;
-}
-
-export interface SelectedVideo {
-  socketID: string;
-  loginID: string;
-  username: string;
-  thumbnail: null | string;
-  stream?: MediaStream;
-  mic: boolean;
-  cam: boolean;
-  speaker: boolean;
-  isScreen: boolean;
-}
-
-interface StreamIDMetaData {
-  camera: string;
-  screen: string;
-}
 
 function MeetVideo() {
   const { userdata } = useUserdata();

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -211,6 +211,16 @@ function MeetVideo() {
     }
   };
 
+  const onScreenShareClick = () => {
+    if (screenShare) {
+      const tracks = myScreenStreamRef.current?.getTracks();
+      tracks?.forEach((track) => track.stop());
+      setScreenShare(false);
+    } else {
+      setScreenShare(true);
+    }
+  };
+
   useEffect(() => {
     if (screenShare) getMyScreen();
     else {
@@ -423,17 +433,7 @@ function MeetVideo() {
           />
         ))}
       </Videos>
-      <MeetButton
-        onScreenShareClick={() => {
-          if (screenShare) {
-            const tracks = myScreenStreamRef.current?.getTracks();
-            tracks?.forEach((track) => track.stop());
-            setScreenShare(false);
-          } else {
-            setScreenShare(true);
-          }
-        }}
-      />
+      <MeetButton onScreenShareClick={onScreenShareClick} />
     </VideoSection>
   );
 }

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -45,7 +45,7 @@ const applyDeviceStatus = ({
   });
 };
 
-export interface IMeetingUser {
+export interface MeetingMember {
   socketID: string;
   loginID: string;
   username: string;
@@ -86,7 +86,7 @@ function MeetVideo() {
   const myScreenRef = useRef<HTMLVideoElement>(null);
   const myScreenStreamRef = useRef<MediaStream>();
   const [screenShare, setScreenShare] = useState(false);
-  const [meetingMembers, setMeetingMembers] = useState<IMeetingUser[]>([]);
+  const [meetingMembers, setMeetingMembers] = useState<MeetingMember[]>([]);
   const pcs = useRef<{ [socketID: string]: RTCPeerConnection }>({});
   const videoCount = videoWrapperRef.current && videoWrapperRef.current.childElementCount;
   const { selectVideo, deselectVideo, selectedVideo, setSelectedVideo } = useSelectVideo();
@@ -112,7 +112,7 @@ function MeetVideo() {
     myStreamRef.current = myStream;
   };
 
-  const createPeerConnection = useCallback((member: IMeetingUser) => {
+  const createPeerConnection = useCallback((member: MeetingMember) => {
     if (pcs.current[member.socketID]) return pcs.current[member.socketID];
     const pc = new RTCPeerConnection(pcConfig);
 
@@ -144,7 +144,7 @@ function MeetVideo() {
     };
 
     pc.ontrack = (e) => {
-      setMeetingMembers((members): IMeetingUser[] => {
+      setMeetingMembers((members): MeetingMember[] => {
         let mem = members.find((m) => m.socketID === member.socketID);
         if (!mem) {
           mem = { ...member, pc };
@@ -243,7 +243,7 @@ function MeetVideo() {
     Socket.joinChannel({ channelType: MeetEvent.meeting, id });
     socket.on(MeetEvent.allMeetingMembers, async (members) => {
       await getMyStream();
-      members.forEach(async (member: IMeetingUser) => {
+      members.forEach(async (member: MeetingMember) => {
         try {
           const pc = createPeerConnection(member);
           if (!pc) return;

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -14,17 +14,9 @@ import Socket, { socket } from 'src/utils/socket';
 import { highlightMyVolume } from 'src/utils/audio';
 import OtherVideo from './OtherVideo';
 import MeetButton from './MeetButton';
-import { MicOffIcon, SpeakerOffIcon } from '@components/common/Icons';
-import {
-  Videos,
-  VideoWrapper,
-  Video,
-  Thumbnail,
-  VideoSection,
-  DeviceStatus,
-  ThumbnailWrapper,
-} from './style';
+import { Videos, VideoSection } from './style';
 import FocusedVideo from './FocusedVideo';
+import MyVideo from './MyVideo';
 
 const ICE_SERVER_URL = 'stun:stun.l.google.com:19302';
 
@@ -413,25 +405,14 @@ function MeetVideo() {
     <VideoSection>
       {selectedVideo && <FocusedVideo selectedVideo={selectedVideo} onClick={deselectVideo} />}
       <Videos ref={videoWrapperRef} videoCount={videoCount || 0} focused={selectedVideo !== null}>
-        <VideoWrapper>
-          <Video autoPlay playsInline muted ref={myVideoRef} />
-          <ThumbnailWrapper>
-            {cam || (
-              <Thumbnail src={userdata?.thumbnail || '/images/default_profile.png'} alt="profile" />
-            )}
-          </ThumbnailWrapper>
-          <p>{`${userdata?.username}(${userdata?.loginID})`}</p>
-          <DeviceStatus>
-            {mic || <MicOffIcon />}
-            {speaker || <SpeakerOffIcon />}
-          </DeviceStatus>
-        </VideoWrapper>
-        {screenShare && (
-          <VideoWrapper>
-            <Video autoPlay playsInline muted ref={myScreenRef} />
-            <p>{`${userdata?.username}(${userdata?.loginID}) 님의 화면`}</p>
-          </VideoWrapper>
-        )}
+        <MyVideo
+          myVideoRef={myVideoRef}
+          myScreenRef={myScreenRef}
+          cam={cam}
+          mic={mic}
+          speaker={speaker}
+          screenShare={screenShare}
+        />
         {meetingMembers.map((member) => (
           <OtherVideo
             key={member.socketID}

--- a/client/src/components/common/Empty/index.tsx
+++ b/client/src/components/common/Empty/index.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 
 import EmptyWrapper from './style';
 
-function Empty() {
+interface EmptyProps {
+  message: string;
+}
+
+function Empty({ message = '' }: EmptyProps) {
   return (
     <EmptyWrapper>
       <div>
         <img src="/images/default_profile.png" alt="select channel" />
-        <p>채널을 선택해주세요!</p>
+        <p>{message}</p>
       </div>
     </EmptyWrapper>
   );

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './useOtherUserdata';
 export * from './useToast';
 export * from './useSelectVideo';
 export * from './useSoundEffect';
+export * from './useSocket';

--- a/client/src/hooks/useSelectVideo.ts
+++ b/client/src/hooks/useSelectVideo.ts
@@ -1,5 +1,5 @@
+import { SelectedVideo } from '@customTypes/meet';
 import { useState, useCallback } from 'react';
-import { SelectedVideo } from '@components/Meet/MeetVideo';
 
 export const useSelectVideo = () => {
   const [selectedVideo, setSelectedVideo] = useState<SelectedVideo | null>(null);

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -1,0 +1,18 @@
+import { InitEvent } from '@customTypes/socket/InitEvent';
+import { useState, useEffect } from 'react';
+import { socket } from 'src/utils/socket';
+
+export const useSocket = () => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    socket.on(InitEvent.INIT_END, () => setIsLoading(false));
+    socket.connect();
+
+    return () => {
+      socket.off(InitEvent.INIT_END);
+    };
+  }, []);
+
+  return isLoading;
+};

--- a/client/src/pages/Loading/index.tsx
+++ b/client/src/pages/Loading/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import Empty from '@components/common/Empty';
+import { LoadingWrapper } from './style';
+
+const NOW_LOADING = '로딩중이에요! 잠시만 기다려주세요!';
+
+function Loading() {
+  return (
+    <LoadingWrapper>
+      <Empty message={NOW_LOADING} />
+    </LoadingWrapper>
+  );
+}
+
+export default Loading;

--- a/client/src/pages/Loading/style.ts
+++ b/client/src/pages/Loading/style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const LoadingWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export { LoadingWrapper };

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -13,6 +13,8 @@ import Empty from '@components/common/Empty';
 import { Layout, MainWrapper } from './style';
 import { Group } from '@customTypes/group';
 
+const NEED_CHANNEL_SELECT = '채널을 선택해주세요!';
+
 function Main() {
   const { groups, isValidating } = useGroups();
   const { groupID, channelType, channelID } = getURLParams();
@@ -53,7 +55,7 @@ function Main() {
             <Meet />
           )
         ) : (
-          <Empty />
+          <Empty message={NEED_CHANNEL_SELECT} />
         )}
       </MainWrapper>
     </Layout>

--- a/client/src/types/meet.ts
+++ b/client/src/types/meet.ts
@@ -1,0 +1,29 @@
+export interface MeetingMember {
+  socketID: string;
+  loginID: string;
+  username: string;
+  thumbnail: string | null;
+  mic: boolean;
+  cam: boolean;
+  speaker: boolean;
+  stream?: MediaStream;
+  screen?: MediaStream;
+  pc?: RTCPeerConnection;
+}
+
+export interface SelectedVideo {
+  socketID: string;
+  loginID: string;
+  username: string;
+  thumbnail: null | string;
+  stream?: MediaStream;
+  mic: boolean;
+  cam: boolean;
+  speaker: boolean;
+  isScreen: boolean;
+}
+
+export interface StreamIDMetaData {
+  camera: string;
+  screen: string;
+}

--- a/client/src/types/socket/InitEvent.ts
+++ b/client/src/types/socket/InitEvent.ts
@@ -1,0 +1,3 @@
+export enum InitEvent {
+  INIT_END = 'initEnd',
+}

--- a/client/src/utils/socket.ts
+++ b/client/src/utils/socket.ts
@@ -2,7 +2,6 @@ import { io } from 'socket.io-client';
 import ChannelEvent from '@customTypes/socket/ChannelEvent';
 
 export const socket = io('/');
-socket.connect();
 
 const joinChannel = ({ channelType, id }: { channelType: 'chatting' | 'meeting'; id: number }) =>
   socket.emit(ChannelEvent.joinChannel, channelType + id);

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -54,8 +54,9 @@ function SocketMeetController(socket) {
   this.offer = ({ offer, receiverID, member, streamID }) => {
     io.to(receiverID).emit(MeetEvent.offer, {
       offer,
-      member: { socketID: socket.id, ...member },
+      member,
       streamID,
+      senderID: socket.id,
     });
   };
 

--- a/server/src/loaders/socket.loader.ts
+++ b/server/src/loaders/socket.loader.ts
@@ -5,6 +5,7 @@ import SocketMeetController from '../controllers/socket/meet.socket';
 import ChannelEvent from '../types/socket/ChannelEvent';
 import ConnectionEvent from '../types/socket/ConnectionEvent';
 import GroupEvent from '../types/socket/GroupEvent';
+import { InitEvent } from '../types/socket/InitEvent';
 import MeetEvent from '../types/socket/MeetEvent';
 
 export let io: Server;
@@ -43,5 +44,7 @@ export async function socketLoader(httpServer) {
     socket.on(MeetEvent.mute, meetController.mute);
     socket.on(MeetEvent.toggleCam, meetController.toggleCam);
     socket.on(MeetEvent.speaker, meetController.speaker);
+
+    io.to(socket.id).emit(InitEvent.INIT_END);
   });
 }

--- a/server/src/types/socket/InitEvent.ts
+++ b/server/src/types/socket/InitEvent.ts
@@ -1,0 +1,3 @@
+export enum InitEvent {
+  INIT_END = 'initEnd',
+}


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #323 
## What did you do?

<!--무엇을 하셨나요?-->
- [x] MeetButton 컴포넌트 위치 수정
- [x] 내 비디오(카메라/화면공유) 요소들을 MyVideo 컴포넌트로 분리
- [x] MeetButton 컴포넌트에 넘겨주는 onScreenShareClick 이벤트 핸들러 함수 분리
- [x] IMeetingUser 인터페이스를 MeetingMember로 명칭 변경
- [x] MeetVideo에서 사용되는 인터페이스들을 types 폴더의 meet.ts로 분리
- [x] createPeerConnection에서 새 멤버를 목록에 추가해 주던 것을 분리
- [x] 로딩 스크린 추가
- [x] 소켓 연결 및 연결이 완료될때까지 로딩스크린을 보여주도록 개선

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
이것저것 많이 고쳤는데 아직도 고칠게 산더미입니다...
교훈은 좀 느리더라도 처음부터 꼼꼼하게 잘 만들자!

