### PR TITLE
Fix : 다음 페이지 요청중일 때는 스크롤이 끝에 도달해도 더 요청하지 않도록 수정

### DIFF
--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -44,10 +44,11 @@ function Chat() {
   }, [id]);
 
   const onScroll = useCallback(() => {
+    if (isValidating) return;
     if (chatListRef?.current?.scrollTop === 0 && !isReachingEnd) {
       setSize((size) => size + 1);
     }
-  }, [isReachingEnd, setSize]);
+  }, [isReachingEnd, setSize, isValidating]);
 
   useEffect(() => {
     if (chatListRef?.current?.scrollTop && chatListRef?.current?.scrollTop > 0) return;


### PR DESCRIPTION
## What did you do?
다음 페이지 요청중일 때는 스크롤이 끝에 도달해도 더 요청하지 않도록 수정하였습니다.
네트워크가 느릴 시 로딩중 여러번 새 페이지를 요청할 수 있는 문제가 있어 수정했습니다.
<!--무엇을 하셨나요?-->
- [x]  다음 페이지 요청중일 때는 스크롤이 끝에 도달해도 더 요청하지 않도록 수정
