### PR TITLE
Fix : 메인페이지 접속시 서버로부터 그룹리스트 가져오기가 완료된 후 렌더링 되도록 수정

### DIFF
--- a/client/src/hooks/useGroups.ts
+++ b/client/src/hooks/useGroups.ts
@@ -8,6 +8,7 @@ import { getFetcher } from '../utils/fetcher';
 import { socket } from '../utils/socket';
 import { useSelectedGroup } from './useSelectedGroup';
 import { Group } from '@customTypes/group';
+import { PublicConfiguration } from 'swr/dist/types';
 
 const getGroupsFetcher = async (url: string) => {
   try {
@@ -20,8 +21,8 @@ const getGroupsFetcher = async (url: string) => {
   }
 };
 
-export const useGroups = () => {
-  const { data: groups, ...rest } = useSWR(API_URL.user.getGroups, getGroupsFetcher);
+export const useGroups = (options?: Partial<PublicConfiguration>) => {
+  const { data: groups, ...rest } = useSWR(API_URL.user.getGroups, getGroupsFetcher, options);
   const { data: userData } = useSWR(API_URL.user.getUserdata, getFetcher);
   const selectedGroup = useSelectedGroup();
   const dispatch = useDispatch();

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React, { Suspense, useLayoutEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { setSelectedChannel } from '@redux/selectedChannel/slice';
@@ -12,11 +12,12 @@ import SideBar from '@components/SideBar';
 import Empty from '@components/common/Empty';
 import { Layout, MainWrapper } from './style';
 import { Group } from '@customTypes/group';
+import Loading from '@pages/Loading';
 
 const NEED_CHANNEL_SELECT = '채널을 선택해주세요!';
 
-function Main() {
-  const { groups, isValidating } = useGroups();
+function MainLayout() {
+  const { groups, isValidating } = useGroups({ suspense: true });
   const { groupID, channelType, channelID } = getURLParams();
   const selectedGroup = useSelectedGroup();
   const selectedChannel = useSelectedChannel();
@@ -59,6 +60,14 @@ function Main() {
         )}
       </MainWrapper>
     </Layout>
+  );
+}
+
+function Main() {
+  return (
+    <Suspense fallback={Loading}>
+      <MainLayout />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #335 
## What did you do?
메인 페이지 진입시 그룹 리스트 로딩이 완료된 후 진입하도록 해 새로고침시 기존 선택된 채널로 복귀하는 과정에서 선택된 채널이 없습니다가 사용자에게 잠시 노출되는 문제를 수정했습니다.
로딩되는 중에는 로딩스크린을 출력하도록 했습니다!
Suspense를 처음 써봤는데 좋네요!
이제 쿼리스트링 쓴거 URL 파라미터 쓰도록 바꿔야 해요...
<!--무엇을 하셨나요?-->
- [x] 메인페이지 접속시 서버로부터 그룹리스트 가져오기가 완료된 후 렌더링 되도록 수정

### 전
![새로고침1](https://user-images.githubusercontent.com/77329061/143398676-c29690cd-466c-4852-8cf7-e7e5282ea4c8.gif)

### 후
![새로고침2](https://user-images.githubusercontent.com/77329061/143398684-46988dd0-72c9-402f-804f-966c64299319.gif)

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
이제 부덕이 분신술 안써요...

## 레퍼런스
<!--참고한 자료가 있나요?-->
https://ko.reactjs.org/docs/concurrent-mode-suspense.html
https://swr.vercel.app/ko/docs/suspense
https://ko.reactjs.org/docs/hooks-reference.html#uselayouteffect