### PR TITLE
Fix : 화면공유 중에는 화면공유 버튼에 ScreenShareStopIcon이 표시되도록 수정

### DIFF
--- a/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
+++ b/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
@@ -7,10 +7,21 @@ import { useSelectedGroup, useToast } from '@hooks/index';
 import { URL } from '@api/URL';
 import { TOAST_MESSAGE } from '@utils/message';
 import { capture } from '@utils/capture';
-import { CaptureIcon, MeetingStopIcon, ScreenShareStartIcon } from '@components/common/Icons';
+import {
+  CaptureIcon,
+  MeetingStopIcon,
+  ScreenShareStartIcon,
+  ScreenShareStopIcon,
+} from '@components/common/Icons';
 import { DarkRedButton, GreenButton, YellowButton, MeetButtonWrapper } from './style';
 
-function MeetButton({ onScreenShareClick }: { onScreenShareClick: () => void }) {
+function MeetButton({
+  onScreenShareClick,
+  screenShare,
+}: {
+  onScreenShareClick: () => void;
+  screenShare: boolean;
+}) {
   const selectedGroup = useSelectedGroup();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -43,7 +54,7 @@ function MeetButton({ onScreenShareClick }: { onScreenShareClick: () => void }) 
   return (
     <MeetButtonWrapper>
       <GreenButton onClick={onScreenShareClick}>
-        <ScreenShareStartIcon />
+        {screenShare ? <ScreenShareStopIcon /> : <ScreenShareStartIcon />}
       </GreenButton>
       <YellowButton onClick={onMeetingCaptureClick}>
         <CaptureIcon />

--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -398,7 +398,7 @@ function MeetVideo() {
           />
         ))}
       </Videos>
-      <MeetButton onScreenShareClick={onScreenShareClick} />
+      <MeetButton screenShare={screenShare} onScreenShareClick={onScreenShareClick} />
     </VideoSection>
   );
 }


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #343 
## What did you do?
화면공유 중에는 화면공유 버튼에 ScreenShareStopIcon이 표시되도록 수정했습니다.

<!--무엇을 하셨나요?-->
- [x]  화면공유 중에는 화면공유 버튼에 ScreenShareStopIcon이 표시되도록 수정

![image](https://user-images.githubusercontent.com/77329061/143435332-c4974ce7-5bc9-40c4-9fcc-2d0b34f12090.png)
