### PR TITLE
Fix : 화면공유 퍼미션 창에서 취소를 눌렀을 때 화면공유가 취소되지 않는 문제 수정

### DIFF
--- a/client/src/components/Meet/MeetVideo/index.tsx
+++ b/client/src/components/Meet/MeetVideo/index.tsx
@@ -168,6 +168,7 @@ function MeetVideo() {
       myScreenStreamRef.current = myScreen;
     } catch (e) {
       console.error(e);
+      setScreenShare(false);
     }
   };
 


### PR DESCRIPTION
catch 문에서 screenShare 상태 false로 바꿔주도록 함

## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #345 
## What did you do?
화면공유 퍼미션 창에서 취소를 눌렀을 때 화면공유가 취소되지 않는 문제가 있었습니다.
MeetVideo 컴포넌트의 getMyScreen 함수 catch문에서 screenShare 값을 false로 되돌려 주지 않아 발생하는 문제였습니다.
<!--무엇을 하셨나요?-->
- [x] 화면공유 퍼미션 창에서 취소를 눌렀을 때 화면공유가 취소되지 않는 문제 수정

