### PR TITLE
Fix : 화상 회의 중 그룹 추가시 정상적으로 퇴장되지 않는 버그 수정 

### DIFF
--- a/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
+++ b/client/src/components/Meet/MeetVideo/MeetButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 
-import { setSelectedChannel } from '@redux/selectedChannel/slice';
+import { resetSelectedChannel } from '@redux/selectedChannel/slice';
 import { useSelectedGroup, useToast } from '@hooks/index';
 import { URL } from '@utils/constants/URL';
 import { TOAST_MESSAGE } from '@utils/constants/MESSAGE';
@@ -28,13 +28,7 @@ function MeetButton({
   const { fireToast } = useToast();
 
   const onMeetingStopClick = () => {
-    dispatch(
-      setSelectedChannel({
-        type: '',
-        id: null,
-        name: '',
-      }),
-    );
+    dispatch(resetSelectedChannel());
     history.replace(URL.GROUP(selectedGroup.id));
   };
 

--- a/client/src/components/Modal/ChannelDelete/index.tsx
+++ b/client/src/components/Modal/ChannelDelete/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 
 import { useGroups, useSelectedGroup, useSelectedChannel, useToast } from '@hooks/index';
-import { setSelectedChannel } from '@redux/selectedChannel/slice';
+import { resetSelectedChannel } from '@redux/selectedChannel/slice';
 import { setSelectedChat } from '@redux/selectedChat/slice';
 import { ModalController } from '@customTypes/modal';
 import Colors from '@styles/Colors';
@@ -50,13 +50,7 @@ export default function ChannelDeleteModal({ controller }: { controller: ModalCo
             }),
             false,
           );
-          dispatch(
-            setSelectedChannel({
-              type: '',
-              id: null,
-              name: '',
-            }),
-          );
+          dispatch(resetSelectedChannel());
           dispatch(setSelectedChat(null));
           controller.hide();
           history.replace(URL.GROUP(selectedGroup.id));

--- a/client/src/components/Modal/GroupCreate/index.tsx
+++ b/client/src/components/Modal/GroupCreate/index.tsx
@@ -14,6 +14,7 @@ import { TOAST_MESSAGE } from '@utils/constants/MESSAGE';
 import { GroupThumbnailUploadIcon } from '@components/common/Icons';
 import Modal from '..';
 import { InputForm, InputImage, InputText } from './style';
+import { resetSelectedChannel } from '@redux/selectedChannel/slice';
 
 function GroupCreateModal({
   controller: { hide, show, previous },
@@ -43,6 +44,7 @@ function GroupCreateModal({
       case 200:
         const group = await response.json();
         mutate([...groups, group], false);
+        dispatch(resetSelectedChannel());
         dispatch(setSelectedGroup(group));
         finishModal();
         history.replace(URL.GROUP(group.id));

--- a/client/src/components/Modal/GroupDelete/index.tsx
+++ b/client/src/components/Modal/GroupDelete/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 
 import { setSelectedGroup } from '@redux/selectedGroup/slice';
-import { setSelectedChannel } from '@redux/selectedChannel/slice';
+import { resetSelectedChannel } from '@redux/selectedChannel/slice';
 import { setSelectedChat } from '@redux/selectedChat/slice';
 import { useSelectedGroup, useGroups, useToast } from '@hooks/index';
 import { URL } from '@utils/constants/URL';
@@ -35,13 +35,7 @@ function GroupDeleteModal({ controller: { hide, show } }: { controller: ModalCon
             false,
           );
           dispatch(setSelectedGroup(null));
-          dispatch(
-            setSelectedChannel({
-              type: '',
-              id: null,
-              name: '',
-            }),
-          );
+          dispatch(resetSelectedChannel());
           dispatch(setSelectedChat(null));
           hide();
           history.replace(URL.GROUP());

--- a/client/src/components/Modal/GroupJoin/index.tsx
+++ b/client/src/components/Modal/GroupJoin/index.tsx
@@ -11,6 +11,7 @@ import { ModalController } from '@customTypes/modal';
 import Colors from '@styles/Colors';
 import Modal from '..';
 import { Input } from './style';
+import { resetSelectedChannel } from '@redux/selectedChannel/slice';
 
 function GroupJoinModal({ controller: { hide, show, previous } }: { controller: ModalController }) {
   const [groupCode, setGroupCode] = useState('');
@@ -33,6 +34,7 @@ function GroupJoinModal({ controller: { hide, show, previous } }: { controller: 
       case 200:
         const group = await response.json();
         mutate([...groups, group], false);
+        dispatch(resetSelectedChannel());
         dispatch(setSelectedGroup(group));
         finishModal();
         history.replace(URL.GROUP(group.id));

--- a/client/src/components/SideBar/GroupNav/index.tsx
+++ b/client/src/components/SideBar/GroupNav/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import { mutate } from 'swr';
 
-import { setSelectedChannel } from '@redux/selectedChannel/slice';
+import { resetSelectedChannel } from '@redux/selectedChannel/slice';
 import { setSelectedGroup } from '@redux/selectedGroup/slice';
 import { setSelectedChat } from '@redux/selectedChat/slice';
 import {
@@ -56,7 +56,7 @@ function GroupNav() {
 
   const selectGroup = (group: Group) => () => {
     history.replace(URL.GROUP(group.id));
-    dispatch(setSelectedChannel({ type: '', id: null, name: '' }));
+    dispatch(resetSelectedChannel());
     dispatch(setSelectedGroup(group));
     socket.emit(SOCKET.GROUP_EVENT.GROUP_ID, group.code);
   };
@@ -73,13 +73,7 @@ function GroupNav() {
       );
       if (code === selectedGroup?.code) {
         dispatch(setSelectedGroup(null));
-        dispatch(
-          setSelectedChannel({
-            type: '',
-            id: null,
-            name: '',
-          }),
-        );
+        dispatch(resetSelectedChannel());
         dispatch(setSelectedChat(null));
         history.replace(URL.GROUP());
       }
@@ -108,13 +102,7 @@ function GroupNav() {
       );
       if (code === selectedGroup?.code)
         if (id === selectedChannel.id && type === selectedChannel.type) {
-          dispatch(
-            setSelectedChannel({
-              type: '',
-              id: null,
-              name: '',
-            }),
-          );
+          dispatch(resetSelectedChannel());
           dispatch(setSelectedChat(null));
           history.replace(URL.GROUP(selectedGroup.id));
         }

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -14,7 +14,7 @@ import { Layout, MainWrapper } from './style';
 import { Group } from '@customTypes/group';
 import Loading from '@pages/Loading';
 
-const NEED_CHANNEL_SELECT = '채널을 선택해주세요!';
+const CHANNEL_SELECT_NEEDED = '채널을 선택해주세요!';
 
 function MainLayout() {
   const { groups, isValidating } = useGroups({ suspense: true });
@@ -56,7 +56,7 @@ function MainLayout() {
             <Meet />
           )
         ) : (
-          <Empty message={NEED_CHANNEL_SELECT} />
+          <Empty message={CHANNEL_SELECT_NEEDED} />
         )}
       </MainWrapper>
     </Layout>

--- a/client/src/redux/selectedChannel/slice.ts
+++ b/client/src/redux/selectedChannel/slice.ts
@@ -11,9 +11,10 @@ const { reducer: selectedChannelReducer, actions } = createSlice({
   initialState: initState,
   reducers: {
     setSelectedChannel: (state, { payload: { type, id, name } }) => ({ type, id, name }),
+    resetSelectedChannel: (state) => ({ ...initState }),
   },
 });
 
-export const { setSelectedChannel } = actions;
+export const { setSelectedChannel, resetSelectedChannel } = actions;
 
 export default selectedChannelReducer;


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #350 
## What did you do?
화상 회의 중 그룹 추가시 selectedChannel을 리셋해주지 않아 기존 채널이 유지되던 버그가 있었습니다.
selectedChannel을 리셋해주지 않아 발생하던 문제였습니다. 그래서 리셋해주는 코드를 추가하는 김에 리듀서에 reset액션이 없없어 추가했습니다.

<!--무엇을 하셨나요?-->
- [x] selectedChannel 리듀서에 resetSelectedChannel 추가
- [x] selectedChannel 리셋을 resetSelectedChannel 액션을 통해 요청하도록 수정
- [x] 화상 회의 중 그룹 추가시 정상적으로 퇴장되지 않는 버그 수정 
- [x] Main 페이지 채널 선택 필요 메시지 상수 명칭을 CHANNEL_SELECT_NEEDED로 변경

![그룹생성 버그 수정](https://user-images.githubusercontent.com/77329061/143672026-2478f059-e2d0-403b-aff7-c77be6d23363.gif)

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
selectedChannel 리듀서를 만들 때 제가 왜 initState를 null로 안했을까요?
코드보니 구조분해 하기전에 null체크 하기 싫어서 그랬던거 같습니다ㅋㅋㅋ

