### PR TITLE
Refactor/백엔드 S3 불러오는 로직 변경, FileItem 컴포넌트 분리

### DIFF
--- a/client/src/components/Chat/ChatInput/index.tsx
+++ b/client/src/components/Chat/ChatInput/index.tsx
@@ -7,6 +7,7 @@ import { TOAST_MESSAGE } from '@utils/constants/MESSAGE';
 import { FileSelectIcon } from '@components/common/Icons';
 import { FileInputWrapper, ChatInputWrapper, Wrapper } from './style';
 import getPresignedUrl from '@utils/getPresignedUrl';
+import FileItem from '../FileItem';
 
 function ChatInput({ scrollToBottom }: { scrollToBottom: () => void }) {
   const { id } = useSelectedChannel();
@@ -55,10 +56,8 @@ function ChatInput({ scrollToBottom }: { scrollToBottom: () => void }) {
         <input ref={chatInputRef} placeholder="Message to channel" />
         {fileURL.length !== 0 && (
           <div>
-            {fileURL.map((url) => (
-              <div key={url}>
-                <img src={url} alt="chatting images" />
-              </div>
+            {fileURL.map((src) => (
+              <FileItem key={src} src={src} alt="chat input file" itemType="chatInput" />
             ))}
           </div>
         )}

--- a/client/src/components/Chat/ChatInput/style.ts
+++ b/client/src/components/Chat/ChatInput/style.ts
@@ -52,14 +52,9 @@ const ChatInputWrapper = styled.div`
     display: flex;
     flex-wrap: wrap;
     overflow: scroll;
+    scrollbar-width: none;
     &::-webkit-scrollbar {
       display: none;
-    }
-    scrollbar-width: none;
-    & img {
-      width: 120px;
-      height: 120px;
-      margin-right: 10px;
     }
   }
 `;

--- a/client/src/components/Chat/ChatItem/index.tsx
+++ b/client/src/components/Chat/ChatItem/index.tsx
@@ -10,6 +10,7 @@ import { STATUS_CODES } from '@utils/constants/STATUS_CODES';
 import ThreadPreview from '../ThreadPreview';
 import AddChatReaction from '../AddChatReaction';
 import ChatReaction from '../ChatReaction';
+import FileItem from '../FileItem';
 import { ChatWrapper, UserImage, FileWrapper, ChatHeader, ChatContent } from './style';
 
 function ChatItem({ chatData }: { chatData: ChatData }) {
@@ -75,10 +76,8 @@ function ChatItem({ chatData }: { chatData: ChatData }) {
         <ChatContent>{content}</ChatContent>
         <FileWrapper>
           {files &&
-            files.map((file) => (
-              <div key={file.src}>
-                <img src={file.src} alt="chat file" />
-              </div>
+            files.map(({ src }) => (
+              <FileItem key={src} src={src} alt="chat file" itemType="chat" />
             ))}
         </FileWrapper>
         <div>

--- a/client/src/components/Chat/ChatItem/style.ts
+++ b/client/src/components/Chat/ChatItem/style.ts
@@ -23,15 +23,6 @@ const UserImage = styled.img`
 const FileWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
-  & div {
-    margin-top: 10px;
-  }
-  & img {
-    max-width: 300px;
-    height: 120px;
-    margin-right: 10px;
-    object-fit: cover;
-  }
 `;
 
 const ChatHeader = styled.div`

--- a/client/src/components/Chat/FileItem/index.tsx
+++ b/client/src/components/Chat/FileItem/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { FileItemWrapper } from './style';
+
+function FileItem({ src, alt, itemType }: { src: string; alt: string; itemType: string }) {
+  return (
+    <FileItemWrapper itemType={itemType}>
+      <img src={src} alt={alt} />
+    </FileItemWrapper>
+  );
+}
+
+export default FileItem;

--- a/client/src/components/Chat/FileItem/index.tsx
+++ b/client/src/components/Chat/FileItem/index.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { FileItemWrapper } from './style';
 
-function FileItem({ src, alt, itemType }: { src: string; alt: string; itemType: string }) {
+interface Props {
+  src: string;
+  alt: string;
+  itemType: string;
+}
+
+function FileItem({ src, alt, itemType }: Props) {
   return (
     <FileItemWrapper itemType={itemType}>
       <img src={src} alt={alt} />

--- a/client/src/components/Chat/FileItem/index.tsx
+++ b/client/src/components/Chat/FileItem/index.tsx
@@ -4,7 +4,7 @@ import { FileItemWrapper } from './style';
 interface Props {
   src: string;
   alt: string;
-  itemType: string;
+  itemType: 'chat' | 'chatInput' | 'thread';
 }
 
 function FileItem({ src, alt, itemType }: Props) {

--- a/client/src/components/Chat/FileItem/style.ts
+++ b/client/src/components/Chat/FileItem/style.ts
@@ -7,11 +7,24 @@ interface IFileNameWrapper {
 const fileImgType = (type: string) => {
   switch (type) {
     case 'chat':
-      return 'max-width: 300px; height: 120px; margin-right: 10px; object-fit: cover;';
+      return `
+      max-width: 300px;
+      height: 120px;
+      margin-right: 10px;
+      object-fit: cover;
+      `;
     case 'chatInput':
-      return 'width: 120px; height: 120px; margin-right: 10px;';
+      return `
+      width: 120px;
+      height: 120px;
+      margin-right: 10px;
+      `;
     case 'thread':
-      return 'max-width: 200px; height: 120px; object-fit: cover;';
+      return `
+      max-width: 200px;
+      height: 120px;
+      object-fit: cover;
+      `;
   }
 };
 

--- a/client/src/components/Chat/FileItem/style.ts
+++ b/client/src/components/Chat/FileItem/style.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+interface IFileNameWrapper {
+  itemType: string;
+}
+
+const fileImgType = (type: string) => {
+  switch (type) {
+    case 'chat':
+      return 'max-width: 300px; height: 120px; margin-right: 10px; object-fit: cover;';
+    case 'chatInput':
+      return 'width: 120px; height: 120px; margin-right: 10px;';
+    case 'thread':
+      return 'max-width: 200px; height: 120px; object-fit: cover;';
+  }
+};
+
+const FileItemWrapper = styled.div<IFileNameWrapper>`
+  margin-top: 10px;
+  & img {
+    ${({ itemType }) => fileImgType(itemType)}
+  }
+`;
+
+export { FileItemWrapper };

--- a/client/src/components/Chat/Thread/index.tsx
+++ b/client/src/components/Chat/Thread/index.tsx
@@ -10,6 +10,7 @@ import { postCreateThread } from '@api/postCreateThread';
 import { getFetcher } from '@utils/fetcher';
 import { socket } from '@utils/socket';
 import ThreadItem from '../ThreadItem';
+import FileItem from '../FileItem';
 import { ThreadCloseIcon } from '../../common/Icons';
 import {
   Input,
@@ -97,10 +98,8 @@ function Thread({ selectedChat }: { selectedChat: ChatData }) {
             <div>{content}</div>
             <FileWrapper>
               {files &&
-                files.map((file) => (
-                  <div key={file.src}>
-                    <img src={file.src} alt="thread files" />
-                  </div>
+                files.map(({ src }) => (
+                  <FileItem key={src} src={src} alt="thread file" itemType="thread" />
                 ))}
             </FileWrapper>
           </div>

--- a/client/src/components/Chat/Thread/style.ts
+++ b/client/src/components/Chat/Thread/style.ts
@@ -137,14 +137,6 @@ const FileWrapper = styled.div`
     background: ${Colors.Gray2};
     border-radius: 10px;
   }
-  & div {
-    margin-top: 10px;
-  }
-  & img {
-    max-width: 200px;
-    height: 120px;
-    object-fit: cover;
-  }
 `;
 
 export {

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -13,7 +13,7 @@ import ChatInput from './ChatInput';
 import ChatItem from './ChatItem';
 import UserConnection from './UserConnection';
 import Thread from './Thread';
-import { ChatContainer, Chats, ChatPart, ChatInputWrapper, StickyWrapper, Section } from './style';
+import { ChatWrapper, Chats, Wrapper, ChatInputWrapper, StickyWrapper, Section } from './style';
 
 const PAGE_SIZE = 20;
 const THRESHOLD = 300;
@@ -136,8 +136,8 @@ function Chat() {
   }, [onChat, onLike, onThread]);
 
   return (
-    <ChatPart>
-      <ChatContainer isSelectedChat={!!selectedChat}>
+    <Wrapper>
+      <ChatWrapper isSelectedChat={!!selectedChat}>
         <Chats ref={chatListRef}>
           {Object.entries(makeChatSection(chats)).map(([day, dayChats]) => (
             <Section key={day}>
@@ -153,9 +153,9 @@ function Chat() {
         <ChatInputWrapper>
           <ChatInput scrollToBottom={scrollToBottom} />
         </ChatInputWrapper>
-      </ChatContainer>
+      </ChatWrapper>
       {selectedChat ? <Thread selectedChat={selectedChat} /> : <UserConnection />}
-    </ChatPart>
+    </Wrapper>
   );
 }
 

--- a/client/src/components/Chat/style.ts
+++ b/client/src/components/Chat/style.ts
@@ -25,17 +25,17 @@ const StickyWrapper = styled.div`
     border: 1.5px solid ${Colors.Gray2};
   }
 `;
-const ChatPart = styled.div`
+const Wrapper = styled.div`
   display: flex;
   width: 100%;
   justify-content: space-between;
 `;
 
-interface IChatContainer {
+interface IChatWrapper {
   isSelectedChat: boolean;
 }
 
-const ChatContainer = styled.div<IChatContainer>`
+const ChatWrapper = styled.div<IChatWrapper>`
   ${(props) => (props.isSelectedChat ? `width: 70%;` : `width: calc(100% - 300px);`)}
   height: calc(100vh - 50px);
   display: flex;
@@ -66,4 +66,4 @@ const ChatInputWrapper = styled.div`
   width: 100%;
 `;
 
-export { ChatContainer, Chats, ChatPart, ChatInputWrapper, StickyWrapper, Section };
+export { ChatWrapper, Chats, Wrapper, ChatInputWrapper, StickyWrapper, Section };

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -2,7 +2,7 @@ import { compare, hash } from 'bcryptjs';
 import { NextFunction, Request, Response } from 'express';
 import { groupMemberRepository, userRepository } from '../loaders/orm.loader';
 import { User } from '../db/entities';
-import { getPresignUrl } from '../utils/S3';
+import { getPresignUrl } from '../utils';
 
 declare module 'express-session' {
   interface SessionData {

--- a/server/src/utils/S3.ts
+++ b/server/src/utils/S3.ts
@@ -19,7 +19,7 @@ const S3 = new AWS.S3({
   signatureVersion: 'v4',
 });
 
-const getPresignUrl = async (fileName) => {
+export const getPresignUrl = async (fileName) => {
   const params = {
     Bucket: bucketName,
     Key: fileName,
@@ -30,5 +30,3 @@ const getPresignUrl = async (fileName) => {
   const signedUrlPut = await S3.getSignedUrlPromise('putObject', params);
   return signedUrlPut;
 };
-
-export { getPresignUrl };

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './access-control.middleware';
 export * from './broadcast';
+export * from './S3';


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->

## What did you do?

<!--무엇을 하셨나요?-->
- [x]  S3 index에서 가져오도록 수정
- [x]  Chat 컴포넌트 스타일 태그 이름 변경
- [x]  FileItem 컴포넌트 분리

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
프론트 컴포넌트를 부모자식간 계층적으로 모아두면 좋을 것 같아요
여러 곳에서 쓰이는건 어디에 모아두는게 좋을지 고민이 되네요!

## 레퍼런스
<!--참고한 자료가 있나요?-->

