### PR TITLE
Refactor Fix : 인피니트 스크롤 개선, Chat 컴포넌트 코드 분리, 기타 버그 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 
 import SignIn from '@pages/SignIn';
 import SignUp from '@pages/SignUp';
@@ -22,7 +22,16 @@ function App() {
       <Switch>
         <RestrictedRoute signIn={false} redirectPath="/main" exact path="/" component={SignIn} />
         <RestrictedRoute signIn={false} redirectPath="/" path="/signup" component={SignUp} />
-        <RestrictedRoute signIn={true} redirectPath="/" path="/main" component={Main} />
+        <RestrictedRoute
+          signIn={true}
+          redirectPath="/"
+          path="/main"
+          component={() => (
+            <Suspense fallback={<Loading />}>
+              <Main />
+            </Suspense>
+          )}
+        />
       </Switch>
     </div>
   );

--- a/client/src/components/Chat/index.tsx
+++ b/client/src/components/Chat/index.tsx
@@ -1,151 +1,26 @@
-import React, { useCallback, useEffect, useRef } from 'react';
-import useSWRInfinite from 'swr/infinite';
+import React, { useEffect } from 'react';
 
-import { useSelectedChannel, useSelectedChat } from '@hooks/index';
+import { useChatInfinite, useChatSocket, useScroll, useSelectedChat } from '@hooks/index';
 import { ChatData } from '@customTypes/chats';
-import Socket, { socket } from '@utils/socket';
-import { getFetcher } from '@utils/fetcher';
+
 import { makeChatSection } from '@utils/makeChatSection';
-import { getChatsHeight } from '@utils/getChatsHeight';
-import { API_URL } from '@utils/constants/API_URL';
-import { SOCKET } from '@utils/constants/SOCKET_EVENT';
+
 import ChatInput from './ChatInput';
 import ChatItem from './ChatItem';
 import UserConnection from './UserConnection';
 import Thread from './Thread';
 import { ChatContainer, Chats, ChatPart, ChatInputWrapper, StickyWrapper, Section } from './style';
 
-const PAGE_SIZE = 20;
-const THRESHOLD = 300;
-const OBSERVER_ROOT_MARGIN = '300px 0px 0px 0px';
-
 function Chat() {
-  const { id } = useSelectedChannel();
+  const { chats, chatListRef, observedTarget } = useChatInfinite();
+  const { scrollToBottom } = useScroll<'div'>(chatListRef);
   const selectedChat = useSelectedChat();
-  const {
-    data: chats,
-    mutate,
-    setSize,
-    isValidating,
-  } = useSWRInfinite(API_URL.CHANNEL.GET_BY_PAGE(id), getFetcher, { suspense: true });
-  const isValidatingRef = useRef(false);
-  isValidatingRef.current = isValidating;
-  const isEmpty = !chats?.length;
-  const isReachingEnd = useRef(false);
-  isReachingEnd.current = isEmpty || (chats && chats[chats.length - 1]?.length < PAGE_SIZE);
-  const observedTarget = useRef<HTMLDivElement>(null);
-  const chatListRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (id === null) return;
-    Socket.joinChannel({ channelType: 'chatting', id });
-
-    return () => {
-      Socket.leaveChannel({ channelType: 'chatting', id });
-    };
-  }, [id]);
-
-  useEffect(() => {
-    if (isValidating) return;
-    if (chatListRef?.current?.scrollTop && chatListRef?.current?.scrollTop > 0) return;
-    (async () => {
-      if (chats) {
-        const height = await getChatsHeight(chatListRef, chats[chats.length - 1]?.length);
-        chatListRef.current?.scrollTo({ top: height });
-      }
-    })();
-  }, [isValidating]);
-
-  const onIntersect = useCallback(
-    ([entry]) => {
-      if (isValidatingRef.current) return;
-      if (entry.isIntersecting && !isReachingEnd.current) {
-        setSize((size) => size + 1);
-      }
-    },
-    [setSize],
-  );
-
-  useEffect(() => {
-    if (!observedTarget.current) return;
-    if (!chatListRef.current) return;
-    const chatListEl = chatListRef.current;
-    const observer = new IntersectionObserver(onIntersect, {
-      root: chatListEl,
-      rootMargin: OBSERVER_ROOT_MARGIN,
-    });
-    observer.observe(observedTarget.current);
-
-    return () => observer.disconnect();
-  }, []);
-
-  const scrollToBottom = (smooth: boolean = true) => {
-    chatListRef.current?.scrollTo({
-      top: chatListRef.current?.scrollHeight,
-      behavior: smooth ? 'smooth' : 'auto',
-    });
-  };
 
   useEffect(() => {
     scrollToBottom(false);
   }, []);
 
-  const onChat = useCallback(
-    async (chat: ChatData) => {
-      await mutate((chats) => {
-        if (!chats) return [chat];
-        return [chat, ...chats];
-      }, false);
-      if (chatListRef.current === null) return;
-      const { scrollTop, clientHeight, scrollHeight } = chatListRef.current;
-      if (scrollHeight - (scrollTop + clientHeight) < THRESHOLD) scrollToBottom();
-    },
-    [mutate],
-  );
-
-  const onLike = useCallback(
-    (info: any) => {
-      mutate((chats) => {
-        if (!chats) return chats;
-        return chats
-          .flat()
-          .map((chat: any) =>
-            chat.id === info.chatID ? { ...chat, reactionsCount: info.reactionsCount } : chat,
-          );
-      }, false);
-    },
-    [mutate],
-  );
-
-  const onThread = useCallback(
-    (info: any) => {
-      mutate((chats) => {
-        if (!chats) return chats;
-        return chats.flat().map((chat: ChatData) =>
-          chat.id === info.chatID
-            ? {
-                ...chat,
-                threadsCount: info.threadsCount,
-                threadWriter: info.threadWriter,
-                threadLastTime: info.threadLastTime,
-              }
-            : chat,
-        );
-      }, false);
-    },
-    [mutate],
-  );
-
-  useEffect(() => {
-    socket.on(SOCKET.CHAT_EVENT.CHAT, onChat);
-    socket.on(SOCKET.CHAT_EVENT.LIKE, onLike);
-    socket.on(SOCKET.CHAT_EVENT.THREAD, onThread);
-    return () => {
-      socket.off(SOCKET.CHAT_EVENT.CHAT);
-      socket.off(SOCKET.CHAT_EVENT.LIKE);
-      socket.off(SOCKET.CHAT_EVENT.THREAD);
-    };
-  }, [onChat, onLike, onThread]);
+  useChatSocket(chatListRef);
 
   return (
     <ChatPart>

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -11,3 +11,7 @@ export * from './useOtherUserdata';
 export * from './useToast';
 export * from './useSelectVideo';
 export * from './useSocket';
+export * from './useScroll';
+export * from './useChatSocket';
+export * from './useChats';
+export * from './useChatInfinite';

--- a/client/src/hooks/useChatInfinite.ts
+++ b/client/src/hooks/useChatInfinite.ts
@@ -1,0 +1,55 @@
+import { getChatsHeight } from '@utils/getChatsHeight';
+import { useRef, useEffect, useCallback } from 'react';
+import { useScroll, useSelectedChannel, useChats } from '.';
+
+const PAGE_SIZE = 20;
+const OBSERVER_ROOT_MARGIN = '300px 0px 0px 0px';
+
+export const useChatInfinite = () => {
+  const chatListRef = useRef<HTMLDivElement>(null);
+  const { scrollTo } = useScroll<'div'>(chatListRef);
+  const { id } = useSelectedChannel();
+  const { chats, setSize, isValidating } = useChats(id);
+  const isValidatingRef = useRef(false);
+  isValidatingRef.current = isValidating;
+  const isEmpty = !chats?.length;
+  const isReachingEnd = useRef(false);
+  isReachingEnd.current = isEmpty || (chats && chats[chats.length - 1]?.length < PAGE_SIZE);
+  const observedTarget = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isValidating) return;
+    if (chatListRef?.current?.scrollTop && chatListRef?.current?.scrollTop > 0) return;
+    (async () => {
+      if (chats) {
+        const height = await getChatsHeight(chatListRef, chats[chats.length - 1]?.length);
+        scrollTo({ top: height });
+      }
+    })();
+  }, [isValidating]);
+
+  const onIntersect = useCallback(
+    ([entry]) => {
+      if (isValidatingRef.current) return;
+      if (entry.isIntersecting && !isReachingEnd.current) {
+        setSize((size) => size + 1);
+      }
+    },
+    [setSize],
+  );
+
+  useEffect(() => {
+    if (!observedTarget.current) return;
+    if (!chatListRef.current) return;
+    const chatListEl = chatListRef.current;
+    const observer = new IntersectionObserver(onIntersect, {
+      root: chatListEl,
+      rootMargin: OBSERVER_ROOT_MARGIN,
+    });
+    observer.observe(observedTarget.current);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return { chats, chatListRef, observedTarget };
+};

--- a/client/src/hooks/useChatSocket.ts
+++ b/client/src/hooks/useChatSocket.ts
@@ -1,0 +1,80 @@
+import { ChatData } from '@customTypes/chats';
+import { SOCKET } from '@utils/constants/SOCKET_EVENT';
+import Socket, { socket } from '@utils/socket';
+import { useCallback, useEffect } from 'react';
+import { useScroll, useSelectedChannel } from '.';
+import { useChats } from './useChats';
+
+const THRESHOLD = 300;
+
+export const useChatSocket = (chatListRef: React.RefObject<HTMLDivElement>) => {
+  const { id } = useSelectedChannel();
+  const { mutate } = useChats(id);
+  const { scrollToBottom } = useScroll<'div'>(chatListRef);
+
+  const onChat = useCallback(
+    async (chat: ChatData) => {
+      await mutate((chats) => {
+        if (!chats) return [chat];
+        return [chat, ...chats];
+      }, false);
+      if (chatListRef.current === null) return;
+      const { scrollTop, clientHeight, scrollHeight } = chatListRef.current;
+      if (scrollHeight - (scrollTop + clientHeight) < THRESHOLD) scrollToBottom();
+    },
+    [mutate],
+  );
+
+  const onLike = useCallback(
+    (info: any) => {
+      mutate((chats) => {
+        if (!chats) return chats;
+        return chats
+          .flat()
+          .map((chat: any) =>
+            chat.id === info.chatID ? { ...chat, reactionsCount: info.reactionsCount } : chat,
+          );
+      }, false);
+    },
+    [mutate],
+  );
+
+  const onThread = useCallback(
+    (info: any) => {
+      mutate((chats) => {
+        if (!chats) return chats;
+        return chats.flat().map((chat: ChatData) =>
+          chat.id === info.chatID
+            ? {
+                ...chat,
+                threadsCount: info.threadsCount,
+                threadWriter: info.threadWriter,
+                threadLastTime: info.threadLastTime,
+              }
+            : chat,
+        );
+      }, false);
+    },
+    [mutate],
+  );
+
+  useEffect(() => {
+    if (id === null) return;
+    Socket.joinChannel({ channelType: 'chatting', id });
+
+    return () => {
+      Socket.leaveChannel({ channelType: 'chatting', id });
+    };
+  }, [id]);
+
+  useEffect(() => {
+    socket.on(SOCKET.CHAT_EVENT.CHAT, onChat);
+    socket.on(SOCKET.CHAT_EVENT.LIKE, onLike);
+    socket.on(SOCKET.CHAT_EVENT.THREAD, onThread);
+    return () => {
+      socket.off(SOCKET.CHAT_EVENT.CHAT);
+      socket.off(SOCKET.CHAT_EVENT.LIKE);
+      socket.off(SOCKET.CHAT_EVENT.THREAD);
+    };
+  }, [onChat, onLike, onThread]);
+};

--- a/client/src/hooks/useChats.ts
+++ b/client/src/hooks/useChats.ts
@@ -1,0 +1,11 @@
+import useSWRInfinite from 'swr/infinite';
+
+import { API_URL } from '@utils/constants/API_URL';
+import { getFetcher } from '@utils/fetcher';
+
+export const useChats = (id: number | null) => {
+  const { data: chats, ...rest } = useSWRInfinite(API_URL.CHANNEL.GET_BY_PAGE(id), getFetcher, {
+    suspense: true,
+  });
+  return { chats, ...rest };
+};

--- a/client/src/hooks/useScroll.ts
+++ b/client/src/hooks/useScroll.ts
@@ -1,0 +1,18 @@
+import { MutableRefObject, RefObject, useCallback, useRef } from 'react';
+
+export const useScroll = <T extends keyof HTMLElementTagNameMap>(
+  targetRef: RefObject<HTMLElementTagNameMap[T]>,
+) => {
+  const scrollTo = useCallback((options?: ScrollToOptions) => {
+    targetRef.current?.scrollTo(options);
+  }, []);
+
+  const scrollToBottom = (smooth: boolean = true) => {
+    targetRef.current?.scrollTo({
+      top: targetRef.current?.scrollHeight,
+      behavior: smooth ? 'smooth' : 'auto',
+    });
+  };
+
+  return { scrollTo, scrollToBottom };
+};

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -50,7 +50,9 @@ function MainLayout() {
         <ChannelHeader />
         {selectedChannel.type ? (
           selectedChannel.type === 'chatting' ? (
-            <Chat />
+            <Suspense fallback={() => <Empty message={'로딩 중!'} />}>
+              <Chat />
+            </Suspense>
           ) : (
             <Meet />
           )

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -12,11 +12,10 @@ import SideBar from '@components/SideBar';
 import Empty from '@components/common/Empty';
 import { Layout, MainWrapper } from './style';
 import { Group } from '@customTypes/group';
-import Loading from '@pages/Loading';
 
 const NEED_CHANNEL_SELECT = '채널을 선택해주세요!';
 
-function MainLayout() {
+function Main() {
   const { groups } = useGroups({ suspense: true });
   const { groupID, channelType, channelID } = getURLParams();
   const selectedGroup = useSelectedGroup();
@@ -50,7 +49,7 @@ function MainLayout() {
         <ChannelHeader />
         {selectedChannel.type ? (
           selectedChannel.type === 'chatting' ? (
-            <Suspense fallback={() => <Empty message={'로딩 중!'} />}>
+            <Suspense fallback={<Empty message={'로딩 중!'} />}>
               <Chat />
             </Suspense>
           ) : (
@@ -61,14 +60,6 @@ function MainLayout() {
         )}
       </MainWrapper>
     </Layout>
-  );
-}
-
-function Main() {
-  return (
-    <Suspense fallback={Loading}>
-      <MainLayout />
-    </Suspense>
   );
 }
 

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -17,14 +17,13 @@ import Loading from '@pages/Loading';
 const NEED_CHANNEL_SELECT = '채널을 선택해주세요!';
 
 function MainLayout() {
-  const { groups, isValidating } = useGroups({ suspense: true });
+  const { groups } = useGroups({ suspense: true });
   const { groupID, channelType, channelID } = getURLParams();
   const selectedGroup = useSelectedGroup();
   const selectedChannel = useSelectedChannel();
   const dispatch = useDispatch();
 
   useLayoutEffect(() => {
-    if (isValidating) return;
     if (selectedGroup !== null || groupID === null) return;
 
     const group = groups?.find((group: Group) => group.id.toString() === groupID) ?? null;
@@ -42,7 +41,7 @@ function MainLayout() {
     if (!id || !name) return;
 
     dispatch(setSelectedChannel({ id, name, type: channelType }));
-  }, [isValidating]);
+  }, []);
 
   return (
     <Layout>


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #362 
- close #361 
- close #360 
## What did you do?
Chat 컴포넌트를 suspense이용해 첫 메시지 데이터를 받고 렌더링 되게 했습니다. 때문에 빈 의존성 배열을 가진 useEffect에서 스크롤을 내려주면 되어 예전처럼 첫 데이터를 받아 왔는지 복잡하게 체크하지 않아도 됩니다.
Main 페이지 컴포넌트의 useLayoutEffect에 suspense 사용으로 인해 필요 없어진 의존성을 제거했습니다. 이제 최초 마운트시 1회만 effect가 실행되어 URL의 쿼리스트링으로 부터 얻은 데이터로 선택 그룹/채널 상태를 초기화 합니다. 따라서 더 이상 불필요한 effect 실행이 일어나지 않습니다.
Functions are not valid as a React child. 워닝이 콘솔창에 뜬다는 제보를 받았습니다. Suspense의 fallback에 JSX(리액트 요소)를 넣어야 하는데 컴포넌트 함수를 넣고 ㅇㅆ었습니다. 앞으로는 문서를 똑바로 읽겠습니다... 라우터랑 헷갈려서 그런 것 같습니다... 죄송... 죄송 ㅠㅠ
Chat 컴포넌트의 인피니트 스크롤 로직과 소켓 통신 로직을 각각 별도의 커스텀 훅으로 분리해보았습니다...
더 예쁘게 쪼개고 싶은데 잘 안되네요 ㅠ

<!--무엇을 하셨나요?-->
- [x] 채팅 채널 입장시 스크롤을 최하단으로 내려주는 로직 수정
- [x] Main 페이지 컴포넌트의 useLayoutEffect에서 suspense 사용으로 필요없어진 의존성 제거
- [x] 인피니트 스크롤을 scroll 이벤트 대신 IntersectionObserver 이용하도록 개선
- [x] Functions are not valid as a React child 에러 수정
- [x] Chat 컴포넌트 로직 커스텀훅으로 분리

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
앞으로 새기술 도입전 문서를 더 꼼꼼히 읽겠습니다😥
## 레퍼런스
<!--참고한 자료가 있나요?-->
https://ko.reactjs.org/docs/react-api.html#reactsuspense
