### PR TITLE
Feat : CustomError와 CatchError 데코레이터 추가와 그에 따른 에러 핸들링 미들웨어 수정

### DIFF
--- a/server/src/controllers/channel.controller.ts
+++ b/server/src/controllers/channel.controller.ts
@@ -6,22 +6,21 @@ import { Chat } from '../db/entities';
 import { File } from '../db/entities';
 import { broadcast } from '../utils';
 import { createChatMSG } from '../messages';
+import { CatchError } from '../utils/CatchError';
 
-const getChat = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+class ChannelController {
+  @CatchError
+  async getChat(req: Request, res: Response, next: NextFunction) {
     const { userID } = req.session;
     const { chattingChannelID } = req.params;
     const page = +req.query.page;
     const chats = await chatRepository.findChatsByPages(chattingChannelID, page, userID);
 
     return res.status(200).json(chats);
-  } catch (error) {
-    next(error);
   }
-};
 
-const createChat = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async createChat(req: Request, res: Response, next: NextFunction) {
     const { content, files, user, chattingChannel } = req.body;
 
     const newChat = new Chat();
@@ -62,9 +61,7 @@ const createChat = async (req: Request, res: Response, next: NextFunction) => {
     });
 
     return res.status(200).send(createChatMSG.success);
-  } catch (error) {
-    next(error);
   }
-};
+}
 
-export default { getChat, createChat };
+export default new ChannelController();

--- a/server/src/controllers/channel.controller.ts
+++ b/server/src/controllers/channel.controller.ts
@@ -5,7 +5,7 @@ import { chatRepository, fileRepository } from '../loaders/orm.loader';
 import { Chat } from '../db/entities';
 import { File } from '../db/entities';
 import { broadcast } from '../utils';
-import { createChatMSG } from '../messages';
+import { CREATE_CHAT_MSG } from '../messages';
 import { CatchError } from '../utils/CatchError';
 
 class ChannelController {
@@ -60,7 +60,7 @@ class ChannelController {
       channelID: `${chattingChannel.id}`,
     });
 
-    return res.status(200).send(createChatMSG.success);
+    return res.status(200).send(CREATE_CHAT_MSG.SUCCESS);
   }
 }
 

--- a/server/src/controllers/chat.controller.ts
+++ b/server/src/controllers/chat.controller.ts
@@ -4,7 +4,7 @@ import { chatRepository, threadRepository, reactionRepository } from '../loaders
 
 import { Thread } from '../db/entities';
 import { broadcast } from '../utils';
-import { handleReactionMSG, createChatMSG } from '../messages';
+import { HANDLE_REACTION_MSG, CREATE_CHAT_MSG } from '../messages';
 import { CatchError } from '../utils/CatchError';
 
 class ChatController {
@@ -18,12 +18,12 @@ class ChatController {
     if (!reaction) {
       await reactionRepository.insert({ user: user, chat: chat });
       chat.reactionsCount += 1;
-      message = handleReactionMSG.addReactionSuccess;
+      message = HANDLE_REACTION_MSG.ADD_REACTION_SUCCESS;
       res.status(201);
     } else {
       await reactionRepository.remove(reaction);
       chat.reactionsCount -= 1;
-      message = handleReactionMSG.deleteReactionSuccess;
+      message = HANDLE_REACTION_MSG.DELETE_REACTION_SUCCESS;
       res.status(204);
     }
     await chatRepository.save(chat);
@@ -72,7 +72,7 @@ class ChatController {
       chatID: chat.id,
     });
 
-    return res.status(200).send(createChatMSG.success);
+    return res.status(200).send(CREATE_CHAT_MSG.SUCCESS);
   }
 
   @CatchError

--- a/server/src/controllers/chat.controller.ts
+++ b/server/src/controllers/chat.controller.ts
@@ -5,10 +5,13 @@ import { chatRepository, threadRepository, reactionRepository } from '../loaders
 import { Thread } from '../db/entities';
 import { broadcast } from '../utils';
 import { handleReactionMSG, createChatMSG } from '../messages';
+import { CatchError } from '../utils/CatchError';
 
-const handleReaction = async (req: Request, res: Response, next: NextFunction) => {
-  const { user, chat } = req.body;
-  try {
+class ChatController {
+  @CatchError
+  async handleReaction(req: Request, res: Response, next: NextFunction) {
+    const { user, chat } = req.body;
+
     const reaction = await reactionRepository.findOne({ where: { user: user, chat: chat } });
 
     let message;
@@ -32,13 +35,10 @@ const handleReaction = async (req: Request, res: Response, next: NextFunction) =
       channelID: chat.chattingChannel.id,
     });
     return res.json({ chat, message });
-  } catch (error) {
-    next(error);
   }
-};
 
-const createThread = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async createThread(req: Request, res: Response, next: NextFunction) {
     const { chat, user, content } = req.body;
     const newThread = new Thread();
     newThread.content = content;
@@ -73,20 +73,15 @@ const createThread = async (req: Request, res: Response, next: NextFunction) => 
     });
 
     return res.status(200).send(createChatMSG.success);
-  } catch (error) {
-    next(error);
   }
-};
 
-const getThread = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async getThread(req: Request, res: Response, next: NextFunction) {
     const { chatID } = req.params;
     const threads = await threadRepository.findThreadsByChatID(chatID);
 
     return res.status(200).send(threads);
-  } catch (error) {
-    next(error);
   }
-};
+}
 
-export default { createThread, handleReaction, getThread };
+export default new ChatController();

--- a/server/src/controllers/user.controller.test.ts
+++ b/server/src/controllers/user.controller.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 
 import { appInit } from '..';
 import { userRepository } from '../loaders/orm.loader';
-import { signInMSG } from '../messages';
+import { SIGN_IN_MSG } from '../messages';
 
 let app;
 
@@ -54,7 +54,7 @@ describe('POST /user/signin', () => {
         .expect(200)
         .end((err, res) => {
           if (err) return done(err);
-          expect(res.text).toBe(signInMSG.success);
+          expect(res.text).toBe(SIGN_IN_MSG.SUCCESS);
           done();
         });
     });
@@ -67,7 +67,7 @@ describe('POST /user/signin', () => {
         .expect(400)
         .end((err, res) => {
           if (err) return done(err);
-          expect(res.text).toBe(signInMSG.wrongPassword);
+          expect(res.text).toBe(SIGN_IN_MSG.WRONG_PASSWORD);
           done();
         });
     });
@@ -78,7 +78,7 @@ describe('POST /user/signin', () => {
         .expect(400)
         .end((err, res) => {
           if (err) return done(err);
-          expect(res.text).toBe(signInMSG.userNotFound);
+          expect(res.text).toBe(SIGN_IN_MSG.USER_NOT_FOUND);
           done();
         });
     });

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -2,7 +2,7 @@ import { hash } from 'bcryptjs';
 import { NextFunction, Request, Response } from 'express';
 import { groupMemberRepository, userRepository } from '../loaders/orm.loader';
 import { User } from '../db/entities';
-import { signUpMSG, signInMSG, signOutMSG, getUserGroupsMSG } from '../messages';
+import { SIGN_UP_MSG, SIGN_IN_MSG, SIGN_OUT_MSG, GET_USER_GROUP_MSG } from '../messages';
 import { getPresignUrl } from '../utils';
 import { CatchError } from '../utils/CatchError';
 
@@ -19,7 +19,7 @@ class UserController {
     newUser.password = await hash(password, saltRounds);
     await userRepository.save(newUser);
 
-    return res.status(200).send(signUpMSG.success);
+    return res.status(200).send(SIGN_UP_MSG.SUCCESS);
   }
 
   @CatchError
@@ -27,13 +27,13 @@ class UserController {
     const { userID } = req.body;
 
     req.session.userID = userID;
-    return res.status(200).send(signInMSG.success);
+    return res.status(200).send(SIGN_IN_MSG.SUCCESS);
   }
 
   signOut(req: Request, res: Response, next: NextFunction) {
     return req.session.destroy((error) => {
       if (error) return next(error);
-      return res.status(200).send(signOutMSG.success);
+      return res.status(200).send(SIGN_OUT_MSG.SUCCESS);
     });
   }
 
@@ -49,7 +49,7 @@ class UserController {
   async getUserGroups(req: Request, res: Response, next: NextFunction) {
     const { userID } = req.session;
     const userdata = await userRepository.findByID(userID);
-    if (!userdata) return res.status(400).send(getUserGroupsMSG.userNotFound);
+    if (!userdata) return res.status(400).send(GET_USER_GROUP_MSG.USER_NOT_FOUND);
 
     const groups = await groupMemberRepository.findGroupsByUserID(userID);
 

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -4,13 +4,15 @@ import { groupMemberRepository, userRepository } from '../loaders/orm.loader';
 import { User } from '../db/entities';
 import { signUpMSG, signInMSG, signOutMSG, getUserGroupsMSG } from '../messages';
 import { getPresignUrl } from '../utils';
+import { CatchError } from '../utils/CatchError';
 
 const saltRounds = 10;
 
-const signUp = async (req: Request, res: Response, next: NextFunction) => {
-  const { loginID, username, password } = req.body;
+class UserController {
+  @CatchError
+  async signUp(req: Request, res: Response, next: NextFunction) {
+    const { loginID, username, password } = req.body;
 
-  try {
     const newUser = new User();
     newUser.loginID = loginID;
     newUser.username = username;
@@ -18,38 +20,33 @@ const signUp = async (req: Request, res: Response, next: NextFunction) => {
     await userRepository.save(newUser);
 
     return res.status(200).send(signUpMSG.success);
-  } catch (error) {
-    next(error);
   }
-};
 
-const signIn = async (req: Request, res: Response, next: NextFunction) => {
-  const { userID } = req.body;
+  @CatchError
+  async signIn(req: Request, res: Response, next: NextFunction) {
+    const { userID } = req.body;
 
-  req.session.userID = userID;
-  return res.status(200).send(signInMSG.success);
-};
+    req.session.userID = userID;
+    return res.status(200).send(signInMSG.success);
+  }
 
-const signOut = (req: Request, res: Response, next: NextFunction) => {
-  return req.session.destroy((error) => {
-    if (error) return next(error);
-    return res.status(200).send(signOutMSG.success);
-  });
-};
+  signOut(req: Request, res: Response, next: NextFunction) {
+    return req.session.destroy((error) => {
+      if (error) return next(error);
+      return res.status(200).send(signOutMSG.success);
+    });
+  }
 
-const getUserData = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async getUserData(req: Request, res: Response, next: NextFunction) {
     const { userID } = req.session;
     const userdata = await userRepository.findByID(userID);
 
     return res.status(200).json({ ...userdata, id: userID });
-  } catch (error) {
-    next(error);
   }
-};
 
-const getUserGroups = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async getUserGroups(req: Request, res: Response, next: NextFunction) {
     const { userID } = req.session;
     const userdata = await userRepository.findByID(userID);
     if (!userdata) return res.status(400).send(getUserGroupsMSG.userNotFound);
@@ -57,26 +54,21 @@ const getUserGroups = async (req: Request, res: Response, next: NextFunction) =>
     const groups = await groupMemberRepository.findGroupsByUserID(userID);
 
     return res.status(200).json(groups);
-  } catch (error) {
-    next(error);
   }
-};
 
-const getOtherUserData = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async getOtherUserData(req: Request, res: Response, next: NextFunction) {
     const { id } = req.params;
     const userdata = await userRepository.findByID(Number(id));
 
     return res.status(200).json(userdata);
-  } catch (error) {
-    next(error);
   }
-};
 
-const updateUserData = async (req: Request, res: Response, next: NextFunction) => {
-  const { userID } = req.session;
-  const { username, thumbnail, bio } = req.body;
-  try {
+  @CatchError
+  async updateUserData(req: Request, res: Response, next: NextFunction) {
+    const { userID } = req.session;
+    const { username, thumbnail, bio } = req.body;
+
     const userdata = await userRepository.save({
       id: userID,
       username,
@@ -85,28 +77,14 @@ const updateUserData = async (req: Request, res: Response, next: NextFunction) =
     });
 
     return res.status(200).json(userdata);
-  } catch (error) {
-    next(error);
   }
-};
 
-const getPresignedUrl = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async getPresignedUrl(req: Request, res: Response, next: NextFunction) {
     const uploadName = req.body.uploadName;
     const url = await getPresignUrl(uploadName);
     return res.status(200).json({ url });
-  } catch (error) {
-    next(error);
   }
-};
+}
 
-export default {
-  signUp,
-  signIn,
-  signOut,
-  getUserData,
-  getUserGroups,
-  getOtherUserData,
-  updateUserData,
-  getPresignedUrl,
-};
+export default new UserController();

--- a/server/src/loaders/express.loader.ts
+++ b/server/src/loaders/express.loader.ts
@@ -3,6 +3,7 @@ import session from 'express-session';
 import morgan from 'morgan';
 import { TypeormStore } from 'typeorm-store';
 import { apiRouter } from '../routes/api.router';
+import { CustomError } from '../utils/CatchError';
 import { sessionRepository } from './orm.loader';
 
 export const expressLoader = (app) => {
@@ -23,8 +24,8 @@ export const expressLoader = (app) => {
 
   app.use('/api', apiRouter);
 
-  app.use((err, req: Request, res: Response, next: NextFunction) => {
-    console.error(err);
-    res.status(500).send(err.message);
+  app.use((error, req: Request, res: Response, next: NextFunction) => {
+    !(error instanceof CustomError) && console.error(error);
+    res.status(error.status || 500).send(error.message);
   });
 };

--- a/server/src/messages/channel.mesage.ts
+++ b/server/src/messages/channel.mesage.ts
@@ -1,7 +1,7 @@
-export const createChatMSG = {
-  userNotFound: '존재하지 않는 사용자 입니다.',
-  chatNotFound: '존재하지 않는 텍스트 입니다.',
-  channelNotFound: '존재하지 않는 채널 입니다.',
-  emptyChat: '채팅을 입력해 주세요.',
-  success: '스레드 전송 성공!',
+export const CREATE_CHAT_MSG = {
+  USER_NOT_FOUND: '존재하지 않는 사용자 입니다.',
+  CHAT_NOT_FOUND: '존재하지 않는 텍스트 입니다.',
+  CHANNEL_NOT_FOUND: '존재하지 않는 채널 입니다.',
+  EMPTY_CHAT: '채팅을 입력해 주세요.',
+  SUCCESS: '스레드 전송 성공!',
 };

--- a/server/src/messages/chat.message.ts
+++ b/server/src/messages/chat.message.ts
@@ -1,6 +1,6 @@
-export const handleReactionMSG = {
-  userNotFound: '존재하지 않는 사용자 입니다.',
-  chatNotFound: '존재하지 않는 텍스트 입니다.',
-  deleteReactionSuccess: '좋아요 지우기 성공!',
-  addReactionSuccess: '좋아요 만들기 성공!',
+export const HANDLE_REACTION_MSG = {
+  USER_NOT_FOUND: '존재하지 않는 사용자 입니다.',
+  CHAT_NOT_FOUND: '존재하지 않는 텍스트 입니다.',
+  DELETE_REACTION_SUCCESS: '좋아요 지우기 성공!',
+  ADD_REACTION_SUCCESS: '좋아요 만들기 성공!',
 };

--- a/server/src/messages/user.message.ts
+++ b/server/src/messages/user.message.ts
@@ -1,30 +1,30 @@
-export const signUpMSG = {
-  nullInput: '회원가입에 필요한 데이터를 모두 입력해주세요.',
-  invalidLoginID: 'ID는 영소문자로 시작하는 6~15자의 영소문자 또는 숫자 여야 합니다.',
-  invalidUsername: '유저 이름은 공백없이 1~15자여야 합니다.',
-  invalidPassword: '비밀번호는 8자 이상 영대소문자, 숫자, 특수문자를 최소 1개씩 포함하여야합니다.',
-  usedID: '이미 사용중인 ID 입니다.',
-  success: '회원가입에 성공했습니다.',
+export const SIGN_UP_MSG = {
+  NULL_INPUT: '회원가입에 필요한 데이터를 모두 입력해주세요.',
+  INVALID_LOGIN_ID: 'ID는 영소문자로 시작하는 6~15자의 영소문자 또는 숫자 여야 합니다.',
+  INVALID_USERNAME: '유저 이름은 공백없이 1~15자여야 합니다.',
+  INVALID_PASSWORD: '비밀번호는 8자 이상 영대소문자, 숫자, 특수문자를 최소 1개씩 포함하여야합니다.',
+  USED_ID: '이미 사용중인 ID 입니다.',
+  SUCCESS: '회원가입에 성공했습니다.',
 };
 
-export const signInMSG = {
-  userNotFound: '존재하지 않는 회원입니다.',
-  wrongPassword: '비밀번호가 올바르지 않습니다.',
-  success: '로그인 성공!',
+export const SIGN_IN_MSG = {
+  USER_NOT_FOUND: '존재하지 않는 회원입니다.',
+  WRONG_PASSWORD: '비밀번호가 올바르지 않습니다.',
+  SUCCESS: '로그인 성공!',
 };
 
-export const signOutMSG = {
-  success: '로그아웃 성공!',
+export const SIGN_OUT_MSG = {
+  SUCCESS: '로그아웃 성공!',
 };
 
-export const getUserGroupsMSG = {
-  userNotFound: '존재하지 않는 유저입니다.',
+export const GET_USER_GROUP_MSG = {
+  USER_NOT_FOUND: '존재하지 않는 유저입니다.',
 };
 
-export const updateUserDataMSG = {
-  needUsername: '사용자 이름이 필요합니다.',
-  needThumbnail: '사용자 이미지가 필요합니다.',
-  needBio: '사용자 소개가 필요합니다.',
-  invalidThumbnial: '사용자 이미지 주소가 올바르지 않습니다.',
-  userNotFound: '존재하지 않는 유저입니다.',
+export const UPDATE_USER_DATA_MSG = {
+  NEED_USER_NAME: '사용자 이름이 필요합니다.',
+  NEED_THUMB_NAIL: '사용자 이미지가 필요합니다.',
+  NEED_BIO: '사용자 소개가 필요합니다.',
+  INVALID_THUMBNAIL: '사용자 이미지 주소가 올바르지 않습니다.',
+  USER_NOT_FOUND: '존재하지 않는 유저입니다.',
 };

--- a/server/src/routes/api/channel.router.ts
+++ b/server/src/routes/api/channel.router.ts
@@ -1,14 +1,14 @@
 import { Router } from 'express';
 import channelController from '../../controllers/channel.controller';
 import { accessControl } from '../../utils';
-import { createChatValidator } from '../../utils/validators';
+import { channelValidator } from '../../utils/validators';
 
 export const channelRouter = Router();
 
 channelRouter.post(
   '/:chattingChannelID/create',
   accessControl({ signIn: true }),
-  createChatValidator,
+  channelValidator.createChatValidator,
   channelController.createChat,
 );
 channelRouter.get(

--- a/server/src/routes/api/chat.router.ts
+++ b/server/src/routes/api/chat.router.ts
@@ -1,29 +1,25 @@
 import { Router } from 'express';
 import chatController from '../../controllers/chat.controller';
 import { accessControl } from '../../utils';
-import {
-  createThreadValidator,
-  getThreadValidator,
-  reactionValidator,
-} from '../../utils/validators';
+import { chatValidator } from '../../utils/validators';
 
 export const chatRouter = Router();
 
 chatRouter.post(
   '/:chatID/thread/create',
   accessControl({ signIn: true }),
-  createThreadValidator,
+  chatValidator.createThreadValidator,
   chatController.createThread,
 );
 chatRouter.post(
   '/:chatID/reaction',
   accessControl({ signIn: true }),
-  reactionValidator,
+  chatValidator.reactionValidator,
   chatController.handleReaction,
 );
 chatRouter.get(
   '/:chatID/thread',
   accessControl({ signIn: true }),
-  getThreadValidator,
+  chatValidator.getThreadValidator,
   chatController.getThread,
 );

--- a/server/src/routes/api/group.router.ts
+++ b/server/src/routes/api/group.router.ts
@@ -1,51 +1,44 @@
 import { Router } from 'express';
 import groupController from '../../controllers/group.controller';
 import { accessControl } from '../../utils';
-import {
-  createChannelValidator,
-  createGroupValidator,
-  deleteChannelValidator,
-  deleteGroupValidator,
-  groupIDValidator,
-  joinGroupValidator,
-} from '../../utils/validators';
+import { groupValidator } from '../../utils/validators';
 
 export const groupRouter = Router();
 
 groupRouter.post(
   '/create',
   accessControl({ signIn: true }),
-  createGroupValidator,
+  groupValidator.createGroupValidator,
   groupController.createGroup,
 );
 groupRouter.get(
   '/:id/members',
   accessControl({ signIn: true }),
-  groupIDValidator,
+  groupValidator.groupIDValidator,
   groupController.getGroupMembers,
 );
 groupRouter.post(
   '/:id/channel/create',
   accessControl({ signIn: true }),
-  groupIDValidator,
-  createChannelValidator,
+  groupValidator.groupIDValidator,
+  groupValidator.createChannelValidator,
   groupController.createChannel,
 );
 groupRouter.post(
   '/join',
   accessControl({ signIn: true }),
-  joinGroupValidator,
+  groupValidator.joinGroupValidator,
   groupController.joinGroup,
 );
 groupRouter.delete(
   '/:id',
   accessControl({ signIn: true }),
-  deleteGroupValidator,
+  groupValidator.deleteGroupValidator,
   groupController.deleteGroup,
 );
 groupRouter.delete(
   '/:groupID/:channelType/:channelID',
   accessControl({ signIn: true }),
-  deleteChannelValidator,
+  groupValidator.deleteChannelValidator,
   groupController.deleteChannel,
 );

--- a/server/src/routes/api/user.router.ts
+++ b/server/src/routes/api/user.router.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import userController from '../../controllers/user.controller';
 import { accessControl } from '../../utils';
-import { signInValidator, signUpValidator, updateUserValidator } from '../../utils/validators';
+import { userValidator } from '../../utils/validators';
 
 export const userRouter = Router();
 
@@ -11,20 +11,20 @@ userRouter.get('/:id/profile', accessControl({ signIn: true }), userController.g
 userRouter.post(
   '/signup',
   accessControl({ signIn: false }),
-  signUpValidator,
+  userValidator.signUpValidator,
   userController.signUp,
 );
 userRouter.post(
   '/signin',
   accessControl({ signIn: false }),
-  signInValidator,
+  userValidator.signInValidator,
   userController.signIn,
 );
 userRouter.post('/signout', accessControl({ signIn: true }), userController.signOut);
 userRouter.patch(
   '/profile',
   accessControl({ signIn: true }),
-  updateUserValidator,
+  userValidator.updateUserValidator,
   userController.updateUserData,
 );
 userRouter.post('/presignedurl', accessControl({ signIn: true }), userController.getPresignedUrl);

--- a/server/src/utils/CatchError.ts
+++ b/server/src/utils/CatchError.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+
+function CatchError(target, propertyKey: string, descriptor: PropertyDescriptor) {
+  const method = descriptor.value;
+  descriptor.value = async function (req: Request, res: Response, next: NextFunction) {
+    try {
+      await method(req, res, next);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+class CustomError {
+  message;
+  status;
+  constructor({ message, status }: { message; status: number }) {
+    this.message = message;
+    this.status = status;
+  }
+}
+
+export { CatchError, CustomError };

--- a/server/src/utils/validators/channel.validator.ts
+++ b/server/src/utils/validators/channel.validator.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { userRepository, chattingChannelRepository } from '../../loaders/orm.loader';
-import { createChatMSG } from '../../messages';
+import { CREATE_CHAT_MSG } from '../../messages';
 import { CatchError, CustomError } from '../CatchError';
 
 class ChannelValidator {
@@ -14,11 +14,11 @@ class ChannelValidator {
       where: { id: chattingChannelID },
     });
 
-    if (!user) throw new CustomError({ message: createChatMSG.userNotFound, status: 400 });
+    if (!user) throw new CustomError({ message: CREATE_CHAT_MSG.USER_NOT_FOUND, status: 400 });
     if (!content.trim() && !files.length)
-      throw new CustomError({ message: createChatMSG.emptyChat, status: 400 });
+      throw new CustomError({ message: CREATE_CHAT_MSG.EMPTY_CHAT, status: 400 });
     if (!chattingChannel)
-      throw new CustomError({ message: createChatMSG.channelNotFound, status: 400 });
+      throw new CustomError({ message: CREATE_CHAT_MSG.CHANNEL_NOT_FOUND, status: 400 });
 
     req.body.user = user;
     req.body.chattingChannel = chattingChannel;

--- a/server/src/utils/validators/chat.validator.ts
+++ b/server/src/utils/validators/chat.validator.ts
@@ -1,9 +1,11 @@
 import { NextFunction, Request, Response } from 'express';
 import { userRepository, chatRepository } from '../../loaders/orm.loader';
 import { createChatMSG, handleReactionMSG } from '../../messages';
+import { CatchError, CustomError } from '../CatchError';
 
-export const reactionValidator = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+class ChatValidator {
+  @CatchError
+  async reactionValidator(req: Request, res: Response, next: NextFunction) {
     const { chatID } = req.params;
     const { userID } = req.session;
 
@@ -12,19 +14,16 @@ export const reactionValidator = async (req: Request, res: Response, next: NextF
       where: { id: chatID },
       relations: ['chattingChannel'],
     });
-    if (!user) return res.status(400).send(handleReactionMSG.userNotFound);
-    if (!chat) return res.status(400).send(handleReactionMSG.chatNotFound);
+    if (!user) throw new CustomError({ message: handleReactionMSG.userNotFound, status: 400 });
+    if (!chat) throw new CustomError({ message: handleReactionMSG.chatNotFound, status: 400 });
 
     req.body.user = user;
     req.body.chat = chat;
     next();
-  } catch (e) {
-    next(e);
   }
-};
 
-export const createThreadValidator = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  @CatchError
+  async createThreadValidator(req: Request, res: Response, next: NextFunction) {
     const { content } = req.body;
     const { chatID } = req.params;
     const { userID } = req.session;
@@ -34,25 +33,24 @@ export const createThreadValidator = async (req: Request, res: Response, next: N
       relations: ['chattingChannel'],
     });
 
-    if (!user) return res.status(400).send(createChatMSG.userNotFound);
-    if (!chat) return res.status(400).send(createChatMSG.chatNotFound);
-    if (!content || !content.trim()) return res.status(400).send(createChatMSG.emptyChat);
+    if (!user) throw new CustomError({ message: createChatMSG.userNotFound, status: 400 });
+    if (!chat) throw new CustomError({ message: createChatMSG.chatNotFound, status: 400 });
+    if (!content || !content.trim())
+      throw new CustomError({ message: createChatMSG.emptyChat, status: 400 });
 
     req.body.user = user;
     req.body.chat = chat;
     next();
-  } catch (e) {
-    next(e);
   }
-};
 
-export const getThreadValidator = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+  async getThreadValidator(req: Request, res: Response, next: NextFunction) {
     const { chatID } = req.params;
     const chat = await chatRepository.findOne({ where: { id: chatID } });
-    if (!chat) return res.status(400).send(createChatMSG.chatNotFound);
+    if (!chat) throw new CustomError({ message: createChatMSG.chatNotFound, status: 400 });
     next();
-  } catch (e) {
-    next(e);
   }
-};
+}
+
+const chatValidator = new ChatValidator();
+
+export { chatValidator };

--- a/server/src/utils/validators/chat.validator.ts
+++ b/server/src/utils/validators/chat.validator.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { userRepository, chatRepository } from '../../loaders/orm.loader';
-import { createChatMSG, handleReactionMSG } from '../../messages';
+import { CREATE_CHAT_MSG, HANDLE_REACTION_MSG } from '../../messages';
 import { CatchError, CustomError } from '../CatchError';
 
 class ChatValidator {
@@ -14,8 +14,8 @@ class ChatValidator {
       where: { id: chatID },
       relations: ['chattingChannel'],
     });
-    if (!user) throw new CustomError({ message: handleReactionMSG.userNotFound, status: 400 });
-    if (!chat) throw new CustomError({ message: handleReactionMSG.chatNotFound, status: 400 });
+    if (!user) throw new CustomError({ message: HANDLE_REACTION_MSG.USER_NOT_FOUND, status: 400 });
+    if (!chat) throw new CustomError({ message: HANDLE_REACTION_MSG.CHAT_NOT_FOUND, status: 400 });
 
     req.body.user = user;
     req.body.chat = chat;
@@ -33,10 +33,10 @@ class ChatValidator {
       relations: ['chattingChannel'],
     });
 
-    if (!user) throw new CustomError({ message: createChatMSG.userNotFound, status: 400 });
-    if (!chat) throw new CustomError({ message: createChatMSG.chatNotFound, status: 400 });
+    if (!user) throw new CustomError({ message: CREATE_CHAT_MSG.USER_NOT_FOUND, status: 400 });
+    if (!chat) throw new CustomError({ message: CREATE_CHAT_MSG.CHAT_NOT_FOUND, status: 400 });
     if (!content || !content.trim())
-      throw new CustomError({ message: createChatMSG.emptyChat, status: 400 });
+      throw new CustomError({ message: CREATE_CHAT_MSG.EMPTY_CHAT, status: 400 });
 
     req.body.user = user;
     req.body.chat = chat;
@@ -46,7 +46,7 @@ class ChatValidator {
   async getThreadValidator(req: Request, res: Response, next: NextFunction) {
     const { chatID } = req.params;
     const chat = await chatRepository.findOne({ where: { id: chatID } });
-    if (!chat) throw new CustomError({ message: createChatMSG.chatNotFound, status: 400 });
+    if (!chat) throw new CustomError({ message: CREATE_CHAT_MSG.CHAT_NOT_FOUND, status: 400 });
     next();
   }
 }

--- a/server/src/utils/validators/user.validator.ts
+++ b/server/src/utils/validators/user.validator.ts
@@ -3,6 +3,7 @@ import { IsDefined, IsNotEmpty, Matches, validate } from 'class-validator';
 import { NextFunction, Request, Response } from 'express';
 import { userRepository } from '../../loaders/orm.loader';
 import { signInMSG, signUpMSG, updateUserDataMSG } from '../../messages';
+import { CatchError, CustomError } from '../CatchError';
 import { REGEXP, VALIDATE_OPTIONS } from './utils';
 
 class SignUpData {
@@ -25,38 +26,6 @@ class SignUpData {
   password: string;
 }
 
-export const signUpValidator = async (req: Request, res: Response, next: NextFunction) => {
-  const { loginID, username, password } = req.body;
-
-  try {
-    const signUpData = new SignUpData({ loginID, username, password });
-    const errors = await validate(signUpData, VALIDATE_OPTIONS);
-
-    if (errors.length) return res.status(400).json(errors);
-
-    const isUsedID = await userRepository.findOne({ where: { loginID: loginID } });
-    if (isUsedID) return res.status(400).send(signUpMSG.usedID);
-
-    next();
-  } catch (e) {
-    next(e);
-  }
-};
-
-export const signInValidator = async (req, res, next) => {
-  const { loginID, password } = req.body;
-
-  const user = await userRepository.findOne({ where: { loginID: loginID } });
-  if (!user) return res.status(400).send(signInMSG.userNotFound);
-
-  const isValidPassword = await compare(password, user.password);
-  if (!isValidPassword) return res.status(400).send(signInMSG.wrongPassword);
-
-  req.body.userID = user.id;
-
-  next();
-};
-
 class UpdateUserData {
   constructor({ username, thumbnail, bio }) {
     this.username = username;
@@ -75,19 +44,50 @@ class UpdateUserData {
   bio: string | null;
 }
 
-export const updateUserValidator = async (req: Request, res: Response, next: NextFunction) => {
-  const { userID } = req.session;
-  const userdata = req.body;
+class UserValidator {
+  @CatchError
+  async signUpValidator(req: Request, res: Response, next: NextFunction) {
+    const { loginID, username, password } = req.body;
 
-  try {
-    const newUserData = new UpdateUserData(userdata);
-    const errors = await validate(newUserData, VALIDATE_OPTIONS);
-    if (errors.length) return res.status(400).json(errors);
-    const user = await userRepository.findOne(userID);
-    if (!user) return res.status(400).send(updateUserDataMSG.userNotFound);
+    const signUpData = new SignUpData({ loginID, username, password });
+    const errors = await validate(signUpData, VALIDATE_OPTIONS);
+
+    if (errors.length) throw new CustomError({ message: errors, status: 400 });
+
+    const isUsedID = await userRepository.findOne({ where: { loginID: loginID } });
+    if (isUsedID) throw new CustomError({ message: signUpMSG.usedID, status: 400 });
 
     next();
-  } catch (e) {
-    next(e);
   }
-};
+
+  @CatchError
+  async signInValidator(req, res, next) {
+    const { loginID, password } = req.body;
+
+    const user = await userRepository.findOne({ where: { loginID: loginID } });
+    if (!user) throw new CustomError({ message: signInMSG.userNotFound, status: 400 });
+
+    const isValidPassword = await compare(password, user.password);
+    if (!isValidPassword) throw new CustomError({ message: signInMSG.wrongPassword, status: 400 });
+
+    req.body.userID = user.id;
+
+    next();
+  }
+
+  @CatchError
+  async updateUserValidator(req: Request, res: Response, next: NextFunction) {
+    const { userID } = req.session;
+    const userdata = req.body;
+
+    const newUserData = new UpdateUserData(userdata);
+    const errors = await validate(newUserData, VALIDATE_OPTIONS);
+    if (errors.length) throw new CustomError({ message: errors, status: 400 });
+    const user = await userRepository.findOne(userID);
+    if (!user) throw new CustomError({ message: updateUserDataMSG.userNotFound, status: 400 });
+
+    next();
+  }
+}
+
+export const userValidator = new UserValidator();

--- a/server/src/utils/validators/user.validator.ts
+++ b/server/src/utils/validators/user.validator.ts
@@ -2,7 +2,7 @@ import { compare } from 'bcryptjs';
 import { IsDefined, IsNotEmpty, Matches, validate } from 'class-validator';
 import { NextFunction, Request, Response } from 'express';
 import { userRepository } from '../../loaders/orm.loader';
-import { signInMSG, signUpMSG, updateUserDataMSG } from '../../messages';
+import { SIGN_IN_MSG, SIGN_UP_MSG, UPDATE_USER_DATA_MSG } from '../../messages';
 import { CatchError, CustomError } from '../CatchError';
 import { REGEXP, VALIDATE_OPTIONS } from './utils';
 
@@ -13,16 +13,16 @@ class SignUpData {
     this.password = password;
   }
 
-  @IsNotEmpty({ message: signUpMSG.nullInput })
-  @Matches(REGEXP.LOGIN_ID, { message: signUpMSG.invalidLoginID })
+  @IsNotEmpty({ message: SIGN_UP_MSG.NULL_INPUT })
+  @Matches(REGEXP.LOGIN_ID, { message: SIGN_UP_MSG.INVALID_LOGIN_ID })
   loginID: string;
 
-  @IsNotEmpty({ message: signUpMSG.nullInput })
-  @Matches(REGEXP.USERNAME, { message: signUpMSG.invalidPassword })
+  @IsNotEmpty({ message: SIGN_UP_MSG.NULL_INPUT })
+  @Matches(REGEXP.USERNAME, { message: SIGN_UP_MSG.INVALID_USERNAME })
   username: string;
 
-  @IsNotEmpty({ message: signUpMSG.nullInput })
-  @Matches(REGEXP.PASSWORD, { message: signUpMSG.invalidPassword })
+  @IsNotEmpty({ message: SIGN_UP_MSG.NULL_INPUT })
+  @Matches(REGEXP.PASSWORD, { message: SIGN_UP_MSG.INVALID_PASSWORD })
   password: string;
 }
 
@@ -33,11 +33,11 @@ class UpdateUserData {
     this.bio = bio;
   }
 
-  @IsNotEmpty({ message: updateUserDataMSG.needUsername })
-  @Matches(REGEXP.USERNAME, { message: signUpMSG.invalidUsername })
+  @IsNotEmpty({ message: UPDATE_USER_DATA_MSG.NEED_USER_NAME })
+  @Matches(REGEXP.USERNAME, { message: SIGN_UP_MSG.INVALID_USERNAME })
   username: string;
 
-  @IsDefined({ message: updateUserDataMSG.needThumbnail })
+  @IsDefined({ message: UPDATE_USER_DATA_MSG.NEED_THUMB_NAIL })
   thumbnail: string | null;
 
   @IsDefined()
@@ -55,7 +55,7 @@ class UserValidator {
     if (errors.length) throw new CustomError({ message: errors, status: 400 });
 
     const isUsedID = await userRepository.findOne({ where: { loginID: loginID } });
-    if (isUsedID) throw new CustomError({ message: signUpMSG.usedID, status: 400 });
+    if (isUsedID) throw new CustomError({ message: SIGN_UP_MSG.USED_ID, status: 400 });
 
     next();
   }
@@ -65,10 +65,11 @@ class UserValidator {
     const { loginID, password } = req.body;
 
     const user = await userRepository.findOne({ where: { loginID: loginID } });
-    if (!user) throw new CustomError({ message: signInMSG.userNotFound, status: 400 });
+    if (!user) throw new CustomError({ message: SIGN_IN_MSG.USER_NOT_FOUND, status: 400 });
 
     const isValidPassword = await compare(password, user.password);
-    if (!isValidPassword) throw new CustomError({ message: signInMSG.wrongPassword, status: 400 });
+    if (!isValidPassword)
+      throw new CustomError({ message: SIGN_IN_MSG.WRONG_PASSWORD, status: 400 });
 
     req.body.userID = user.id;
 
@@ -84,7 +85,7 @@ class UserValidator {
     const errors = await validate(newUserData, VALIDATE_OPTIONS);
     if (errors.length) throw new CustomError({ message: errors, status: 400 });
     const user = await userRepository.findOne(userID);
-    if (!user) throw new CustomError({ message: updateUserDataMSG.userNotFound, status: 400 });
+    if (!user) throw new CustomError({ message: UPDATE_USER_DATA_MSG.USER_NOT_FOUND, status: 400 });
 
     next();
   }


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #373 
## What did you do?
이제 미들웨어에서 try/catch문을 반복적으로 작성해 줄 필요 없이 CatchError 데코레이터를 붙여주기만 하면 됩니다.
예외 처리시 응답을 직접 리턴하지 않고 CustomError 클래스를 throw 하면 됩니다.
 
<!--무엇을 하셨나요?-->
- [x] CatchError 데코레이터
- [x] CustomError 클래스
- [x] 에러 핸들링 미들웨어 수정

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->

## 레퍼런스
<!--참고한 자료가 있나요?-->

