### PR TITLE
Fix : 다른사람의 메시지를 수신하고 있을 때 인피니트 스크롤이 동작하지 않는 문제 수정

### DIFF
--- a/client/src/hooks/useChatInfinite.ts
+++ b/client/src/hooks/useChatInfinite.ts
@@ -20,7 +20,6 @@ export const useChatInfinite = (chatListRef: React.RefObject<HTMLDivElement>) =>
 
   useEffect(() => {
     if (isValidating) return;
-    if (chatListRef?.current?.scrollTop && chatListRef?.current?.scrollTop > 0) return;
     (async () => {
       if (chats) {
         const height = await getChatsHeight(chatListRef, chats[chats.length - 1]?.length);


### PR DESCRIPTION
## What did you do?
다른사람의 메시지를 수신하고 있을 때 인피니트 스크롤이 동작하지 않는 문제 수정
<!--무엇을 하셨나요?-->
- [x]  다른사람의 메시지를 수신하고 있을 때 인피니트 스크롤이 동작하지 않는 문제 수정

## 고민한 점, 질문거리
<!--+ 팀원들에게 할 말-->
긴급긴급