### PR TITLE
Fix : 기존 멤버와 WebRTC 연결시 오퍼가 2번 등록되는 문제 수정

### DIFF
--- a/client/src/hooks/useMeeting.ts
+++ b/client/src/hooks/useMeeting.ts
@@ -68,25 +68,13 @@ export const useMeeting = () => {
           if (!pc) return;
           setMeetingMembers((members) => [...members, { ...member, pc }]);
           peerConnections.current = { ...peerConnections.current, [member.socketID]: pc };
-          const offer = await pc.createOffer();
-          await pc.setLocalDescription(offer);
-
-          socket.emit(SOCKET.MEET_EVENT.OFFER, {
-            offer,
-            receiverID: member.socketID,
-            member: { loginID, username, thumbnail, deviceState: { mic, cam, speaker } },
-            streamID: {
-              camera: myStreamRef.current?.id,
-              screen: myScreenStreamRef.current?.id,
-            },
-          });
         } catch (e) {
           console.error(SOCKET.MEET_EVENT.ALL_MEETING_MEMBERS, e);
         }
       });
     });
 
-    socket.on(SOCKET.MEET_EVENT.OFFER, async ({ offer, member, streamID, senderID }) => {
+    socket.on(SOCKET.MEET_EVENT.OFFER, async ({ offer, memberData, streamID, senderID }) => {
       try {
         const pc = createPeerConnection(senderID);
         if (!pc) return;
@@ -95,7 +83,7 @@ export const useMeeting = () => {
             return members;
           else {
             playSoundEffect(SoundEffect.JoinMeeting);
-            return [...members, { ...member, socketID: senderID, pc }];
+            return [...members, { ...memberData, socketID: senderID, pc }];
           }
         });
         streamIDMetaData.current[senderID] = streamID;

--- a/server/src/controllers/socket/meet.socket.ts
+++ b/server/src/controllers/socket/meet.socket.ts
@@ -47,10 +47,12 @@ function SocketMeetController(socket: Socket) {
     io.to(socket.id).emit(MeetEvent.allMeetingMembers, membersInMeeting);
   };
 
-  this.offer = ({ offer, receiverID, member, streamID }) => {
+  this.offer = ({ offer, receiverID, streamID }) => {
+    const meetingID = socketToMeeting[socket.id];
+    const memberData = meetingMembers[meetingID].find((member) => member.socketID === socket.id);
     io.to(receiverID).emit(MeetEvent.offer, {
       offer,
-      member,
+      memberData,
       streamID,
       senderID: socket.id,
     });


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #388 
## What did you do?
기존 멤버와 WebRTC 연결시 오퍼가 2번 등록되는 문제 수정.
dev 브랜치만 수정되어 있어서 release도 수정합니다!


