### PR TITLE
Refactor : RestrictedRoute 컴포넌트에서 RestrictedComponent 분리

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,14 +2,15 @@ import React, { Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import { useSocket } from '@hooks/index';
-import SignIn from '@pages/SignIn';
-import SignUp from '@pages/SignUp';
-import Main from '@pages/Main';
 import Loading from '@pages/Loading';
 import NotFound from '@pages/NotFound';
 import GlobalStyle from '@styles/GlobalStyle';
 import RestrictedRoute from '@components/common/RestrictedRoute';
 import Toast from '@components/common/Toast';
+
+const Main = React.lazy(() => import('@pages/Main'));
+const SignIn = React.lazy(() => import('@pages/SignIn'));
+const SignUp = React.lazy(() => import('@pages/SignUp'));
 
 function App() {
   const isLoading = useSocket();
@@ -20,21 +21,14 @@ function App() {
     <div className="App">
       <GlobalStyle />
       <Toast />
-      <Switch>
-        <RestrictedRoute signIn={false} redirectPath="/main" exact path="/" component={SignIn} />
-        <RestrictedRoute signIn={false} redirectPath="/" path="/signup" component={SignUp} />
-        <RestrictedRoute
-          signIn={true}
-          redirectPath="/"
-          path="/main"
-          component={() => (
-            <Suspense fallback={<Loading />}>
-              <Main />
-            </Suspense>
-          )}
-        />
-        <Route path="*" component={NotFound} />
-      </Switch>
+      <Suspense fallback={<Loading />}>
+        <Switch>
+          <RestrictedRoute signIn={false} redirectPath="/main" exact path="/" component={SignIn} />
+          <RestrictedRoute signIn={false} redirectPath="/" path="/signup" component={SignUp} />
+          <RestrictedRoute signIn={true} redirectPath="/" path="/main" component={Main} />
+          <Route path="*" component={NotFound} />
+        </Switch>
+      </Suspense>
     </div>
   );
 }

--- a/client/src/components/common/Empty/style.ts
+++ b/client/src/components/common/Empty/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const EmptyWrapper = styled.div`
   width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   flex-direction: column;

--- a/client/src/components/common/RestrictedRoute/RestrictedComponent/index.tsx
+++ b/client/src/components/common/RestrictedRoute/RestrictedComponent/index.tsx
@@ -1,0 +1,16 @@
+import { useAccessControl } from '@hooks/index';
+import React from 'react';
+
+interface Props {
+  component: React.ElementType;
+  signIn: boolean;
+  redirectPath: string;
+}
+
+function RestrictedComponent({ component: Component, signIn, redirectPath, ...props }: Props) {
+  useAccessControl({ signIn, redirectPath });
+
+  return <Component {...props} />;
+}
+
+export default React.memo(RestrictedComponent);

--- a/client/src/components/common/RestrictedRoute/index.tsx
+++ b/client/src/components/common/RestrictedRoute/index.tsx
@@ -13,13 +13,8 @@ function RestrictedRoute({ component, signIn, redirectPath, ...rest }: Props) {
   return (
     <Route
       {...rest}
-      render={(props) => (
-        <RestrictedComponent
-          component={component}
-          signIn={signIn}
-          redirectPath={redirectPath}
-          {...props}
-        />
+      component={() => (
+        <RestrictedComponent component={component} signIn={signIn} redirectPath={redirectPath} />
       )}
     />
   );

--- a/client/src/components/common/RestrictedRoute/index.tsx
+++ b/client/src/components/common/RestrictedRoute/index.tsx
@@ -1,23 +1,28 @@
 import React from 'react';
 import { Route, RouteProps } from 'react-router-dom';
-
-import { useAccessControl } from '@hooks/index';
+import RestrictedComponent from './RestrictedComponent';
 
 interface Props extends RouteProps {
   signIn: boolean;
   redirectPath: string;
 }
 
-function RestrictedRoute({ component: Component, signIn, redirectPath, ...rest }: Props) {
-  if (!Component) return null;
+function RestrictedRoute({ component, signIn, redirectPath, ...rest }: Props) {
+  if (!component) return null;
 
-  const RestrictedComponent = (props: any) => {
-    useAccessControl({ signIn, redirectPath });
-
-    return <Component {...props} />;
-  };
-
-  return <Route {...rest} component={RestrictedComponent} />;
+  return (
+    <Route
+      {...rest}
+      render={(props) => (
+        <RestrictedComponent
+          component={component}
+          signIn={signIn}
+          redirectPath={redirectPath}
+          {...props}
+        />
+      )}
+    />
+  );
 }
 
-export default RestrictedRoute;
+export default React.memo(RestrictedRoute);


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #392 
## What did you do?
RestrictedRoute 컴포넌트에서 RestrictedComponent 분리했습니다.
기존에는 RestrictedRoute 컴포넌트 리렌더링시 매번 RestrictedComponent 컴포넌트를 새로 만들게 되어있었습니다.
때문에 RestrictedComponent 컴포넌트를 분리해줬습니다.

<!--무엇을 하셨나요?-->
- [x]  RestrictedRoute 컴포넌트에서 RestrictedComponent 분리

