### PR TITLE
Fix : 유저 인증 확인시 페이지 전체 리렌더링 되는 현상을 수정

### DIFF
--- a/client/src/components/common/RestrictedRoute/index.tsx
+++ b/client/src/components/common/RestrictedRoute/index.tsx
@@ -1,23 +1,20 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Route, RouteProps } from 'react-router-dom';
 import RestrictedComponent from './RestrictedComponent';
 
-interface Props extends RouteProps {
+interface Props extends Omit<RouteProps, 'component'> {
+  component: React.ElementType;
   signIn: boolean;
   redirectPath: string;
 }
 
 function RestrictedRoute({ component, signIn, redirectPath, ...rest }: Props) {
-  if (!component) return null;
-
-  return (
-    <Route
-      {...rest}
-      component={() => (
-        <RestrictedComponent component={component} signIn={signIn} redirectPath={redirectPath} />
-      )}
-    />
+  const Component = useCallback(
+    () => <RestrictedComponent component={component} signIn={signIn} redirectPath={redirectPath} />,
+    [component, redirectPath, signIn],
   );
+
+  return <Route {...rest} component={Component} />;
 }
 
 export default React.memo(RestrictedRoute);


### PR DESCRIPTION
## Related Issues
<!--#을 눌러 이슈와 연결해주세요-->
- close #394 
## What did you do?
유저 인증 확인시 페이지 전체 리렌더링 되는 현상을 수정하였습니다.
useAccessControl에서 SWR의 isValidating 상태를 사용하고 있어 revalidation시 리렌더링 2회 발생하였습니다.
요청을 하면서 false => true로 바뀔 때 1회 응답을 받아서 true => false로 바뀔 때 1회 총 2회 발생하고 있었습니다.
SWR 걷어내고 fetch를 이용해 userdata 요청해서 검증하도록 변경하였습니다.
더 이상 유저 인증을 위한 상태를 사용하고 있지 않기 때문에 인증 확인으로 인한 리렌더링이 더 이상 발생하지 않습니다.
SWR을 걷어냄에 따라 SWR이 제공하던 페이지 복귀시 revalidation 기능을 사용하지 못하게 되었습니다.
때문에 사용자가 세션쿠키를 직접 삭제하고 페이지를 포커스 했을 때 인증 재확인 후 리디렉션 시켜주지 못해 서비스를 정상적으로 사용하지 못하는 상황이 발생했습니다.
이 문제를 해결하기 위해 사용자가 다른 탭,창을 보다 다시 페이지를 포커스 했을 때 재검증 하는 기능은 window에 focus 이벤트 리스너를 달아 구현했습니다.
SWR 사용했을 때와 마찬가지로 세션쿠키를 직접 지우면 포커스와 동시에 재검증 후 리디렉션되도록 하였습니다.

<!--무엇을 하셨나요?-->
- [x] useAccessControl 훅이 SWR을 사용하지 않도록 변경
